### PR TITLE
Save coor feature

### DIFF
--- a/wrapper/Tools/OpenMMMD.py
+++ b/wrapper/Tools/OpenMMMD.py
@@ -1,7 +1,7 @@
 
 ####################################################################################################
 #                                                                                                  #
-#   RUN SCRIPT to perform a MD simulation in Sire with OpenMM                                      #
+#   RUN SCRIPT to perform an MD simulation in Sire with OpenMM                                     #
 #                                                                                                  #
 #   author: Julien Michel                                                                          #
 #   author: Gaetano Calabro                                                                        #
@@ -1216,7 +1216,7 @@ def getAllData(integrator, steps):
     outdata = None
     l = [len(gradients), len(f_metropolis), len(b_metropolis), len(energies), len(steps)]
     if len(set(l))!=1:
-        print("Whoops somehow the data generated does not agree in their first dimensions...exiting now")
+        print("Whoops somehow the data generated does not agree in their first dimensions...exiting now.")
         exit(-1)
     else:
         if len(gradients) == len(reduced_pot_en):
@@ -1226,9 +1226,9 @@ def getAllData(integrator, steps):
         elif len(reduced_pot_en)==0:
             outdata = np.column_stack((steps, energies, gradients,
                                    f_metropolis, b_metropolis))
-            print("Warning: you didn't specify a lambda array, no reduced perturbed energies can be written to file")
+            print("Warning: you didn't specify a lambda array, no reduced perturbed energies can be written to file.")
         else:
-            print("Whoops somehow the data generated does not agree in their first dimensions...exiting now")
+            print("Whoops somehow the data generated does not agree in their first dimensions...exiting now.")
             exit(-1)
     return outdata
 
@@ -1445,7 +1445,7 @@ def runFreeNrg():
         print("Setting up sim file. ")
 
         outfile.write(bytes("#This file was generated on "+time.strftime("%c")+"\n", "UTF-8"))
-        outfile.write(bytes("#Using the somd command, which is part of the molecular library Sire\n","UTF-8"))
+        outfile.write(bytes("#Using the somd command, of the molecular library Sire version <%s> \n" %Sire.__version__,"UTF-8"))
         outfile.write(bytes("#For more information visit: https://github.com/michellab/Sire\n#\n","UTF-8"))
         outfile.write(bytes("#General information on simulation parameters:\n", "UTF-8"))
         outfile.write(bytes("#Simulation used %s moves, %s cycles and %s of simulation time \n" %(nmoves.val,
@@ -1544,15 +1544,6 @@ def runFreeNrg():
         steps = list(range(beg, end, energy_frequency.val))
         outdata = getAllData(integrator, steps)
         gradients = integrator.getGradients()
-        # reduced_energies = integrator.getReducedPerturbedEnergies()
-        # forward_Metropolis = integrator.getForwardMetropolis()
-        # backward_Metropolis = integrator.getBackwardMetropolis()
-        # pot_energies = integrator.getEnergies()
-
-
-        # outdata = np.column_stack((steps, pot_energies, gradients,
-        #                            forward_Metropolis, backward_Metropolis,
-        #                            reduced_energies))
         fmt =" ".join(["%8d"] + ["%25.8e"] + ["%25.8e"] + ["%25.8e"] + ["%25.8e"] + ["%25.15e"]*(len(lambda_array.val)))
         np.savetxt(outfile, outdata, fmt=fmt)
 

--- a/wrapper/__init__.py
+++ b/wrapper/__init__.py
@@ -12,4 +12,4 @@
 #these are vital for the rest of the module
 import Sire.Qt
 import Sire.Error
-
+__version__ = '15.1.0'

--- a/wrapper/python/scripts/analyse_freenrg.py
+++ b/wrapper/python/scripts/analyse_freenrg.py
@@ -1,5 +1,9 @@
 description = """
-analyse_freenrg is an analysis app that has been designed to analyse the output of all free energy calculations in Sire. analyse_freenrg reads in a Sire Saved Stream (.s3) file that contains a list of Sire.Analysis free energy objects (e.g. FEP, TI, Bennetts). analyse_freenrg will average and analyse these free energies according the to options you supply, e.g. assuming that the free energies are stored in freenrgs.s3, and you want to average iterations 100-200 from the simulation, and write the results to ‘results.txt’, type;
+analyse_freenrg is an analysis app that has been designed to analyse the output of all free energy calculations in Sire.
+ analyse_freenrg reads in a Sire Saved Stream (.s3) file that contains a list of Sire.Analysis free energy objects (e.g.
+ FEP, TI, Bennetts). analyse_freenrg will average and analyse these free energies according the to options you supply,
+ e.g. assuming that the free energies are stored in freenrgs.s3, and you want to average iterations 100-200 from the
+ simulation, and write the results to ‘results.txt’, type;
 
 sire.app/bin/analyse_freenrg -i freenrgs.s3 -r 100 200 -o results.txt
 
@@ -9,15 +13,27 @@ sire.app/bin/analyse_freenrg -i freenrgs.s3 -o results.txt
 
 (you can specify the percentage to average using the ‘--percent’ option)
 
-analyse_freenrg automatically knows how many free energies are contained in the s3 file, what their types are and what should be done to analyse the results. For example, the waterswap, ligandswap and quantomm apps all output s3 files that contain FEP, Bennetts and TI free energy data, so analyse_freenrg knows automatically to perform FEP, Bennetts and TI analysis on that data and to report all of the results. analyse_freenrg also knows whether or not finite difference approximations have been used, whether forwards and backwards windows were evaluated, the temperature and conditions of the simulation etc. The aim is that it should handle everything for you, so you can concentrate on looking at the potential of mean force (PMF) or final result.
+analyse_freenrg automatically knows how many free energies are contained in the s3 file, what their types are and what
+should be done to analyse the results. For example, the waterswap, ligandswap and quantomm apps all output s3 files that
+contain FEP, Bennetts and TI free energy data, so analyse_freenrg knows automatically to perform FEP, Bennetts and TI
+analysis on that data and to report all of the results. analyse_freenrg also knows whether or not finite difference
+approximations have been used, whether forwards and backwards windows were evaluated, the temperature and conditions of
+the simulation etc. The aim is that it should handle everything for you, so you can concentrate on looking at the
+potential of mean force (PMF) or final result.
 
-For FEP data, analyse_freenrg will return the FEP PMF across lambda, together with errors based on statistical convergence (95% standard error) and the difference between forwards and backwards free energies (if available).
+For FEP data, analyse_freenrg will return the FEP PMF across lambda, together with errors based on statistical
+convergence (95% standard error) and the difference between forwards and backwards free energies (if available).
 
-For Bennetts data, analyse_freenrg will return the Bennetts Acceptance Ratio PMF across lambda, with errors based on statistical convergence (95% standard error).
+For Bennetts data, analyse_freenrg will return the Bennetts Acceptance Ratio PMF across lambda, with errors based on
+statistical convergence (95% standard error).
 
-For TI data, analyse_free energy will return the PMF across lambda based on polynomial fitting of the gradients and analytic integration of the resulting function. It will also return the integral across lambda using simple quadrature. Errors are based on statistical convergence (95% standard error) and on the difference between the forwards and backwards finite difference gradients (if available, and if finite-difference TI was used).
+For TI data, analyse_free energy will return the PMF across lambda based on polynomial fitting of the gradients and
+analytic integration of the resulting function. It will also return the integral across lambda using simple quadrature.
+Errors are based on statistical convergence (95% standard error) and on the difference between the forwards and
+backwards finite difference gradients (if available, and if finite-difference TI was used).
 
-If you need more help understanding or interpreting the results of an analyse_freenrg analysis then please feel free to get in touch via the Sire users mailing list.
+If you need more help understanding or interpreting the results of an analyse_freenrg analysis then please feel free to
+get in touch via the Sire users mailing list, or by creating a github issue.
 """
 
 from Sire.Analysis import *
@@ -77,9 +93,9 @@ if args.author:
     must_exit = True
 
 if args.version:
-    print("analyse_freenrg -- from Sire release version <%s>" %Sire.__version__)
+    print("analyse_freenrg -- from Sire release version <%s>" % Sire.__version__)
     print("This particular release can be downloaded here: "
-          "https://github.com/michellab/Sire/releases/tag/v%s" %Sire.__version__)
+          "https://github.com/michellab/Sire/releases/tag/v%s" % Sire.__version__)
     must_exit = True
 
 if must_exit:
@@ -123,13 +139,13 @@ else:
 if not input_file:
     if gradient_files:
         input_file = gradient_files
-    
+
 if not input_file:
     parser.print_help()
     print("\nPlease supply the name of the .s3 file(s) containing the free energies/gradients to be analysed.")
     sys.exit(-1)
 
-#elif not os.path.exists(input_file):
+# elif not os.path.exists(input_file):
 #    parser.print_help()
 #    print("\nPlease supply the name of the .s3 file containing the free energies to be analysed.")
 #    print("(cannot find file %s)" % input_file)
@@ -151,56 +167,56 @@ num_inputfiles = len(input_file)
 if gradient_files:
     # Multiple input files provided. Assume we have several gradients files that must be combined
     grads = {}
-    fwds_grads = {} 
-    bwds_grads = {} 
+    fwds_grads = {}
+    bwds_grads = {}
 
-    delta_lambda = None 
+    delta_lambda = None
 
-    for i in range(0,num_inputfiles): 
-        grad = Sire.Stream.load(input_file[i]) 
+    for i in range(0, num_inputfiles):
+        grad = Sire.Stream.load(input_file[i])
 
         #print(grad)
-        analytic_data = grad.analyticData() 
-        fwds_data = grad.forwardsData() 
-        bwds_data = grad.backwardsData() 
+        analytic_data = grad.analyticData()
+        fwds_data = grad.forwardsData()
+        bwds_data = grad.backwardsData()
 
         #print(analytic_data)
         #print(fwds_data)
         #print(bwds_data)
 
-        if len(analytic_data) > 0: 
-             # analytic gradients
+        if len(analytic_data) > 0:
+            # analytic gradients
             #print(analytic_data.keys())
-            lamval = list(analytic_data.keys())[0] 
-            grads[ lamval ] = analytic_data[lamval] 
-        else: 
+            lamval = list(analytic_data.keys())[0]
+            grads[lamval] = analytic_data[lamval]
+        else:
             # finite difference gradients 
-            lamval = list(fwds_data.keys())[0] 
-            fwds_grads[lamval] = fwds_data[lamval] 
-            bwds_grads[lamval] = bwds_data[lamval] 
-            delta_lambda = grad.deltaLambda() 
+            lamval = list(fwds_data.keys())[0]
+            fwds_grads[lamval] = fwds_data[lamval]
+            bwds_grads[lamval] = bwds_data[lamval]
+            delta_lambda = grad.deltaLambda()
 
-    ti = None 
+    ti = None
 
-    if len(grads) > 0 : 
-        ti = TI( Gradients(grads) ) 
-    else: 
-        ti = TI( Gradients(fwds_grads,bwds_grads,delta_lambda) ) 
+    if len(grads) > 0:
+        ti = TI(Gradients(grads))
+    else:
+        ti = TI(Gradients(fwds_grads, bwds_grads, delta_lambda))
 
     input_file = "freenrgs.s3"
     Sire.Stream.save(ti, input_file)
     #freenrgs = ti
 
 # Only one input file provided, assumes it contains freenrgs
-freenrgs = Sire.Stream.load(input_file)    
+freenrgs = Sire.Stream.load(input_file)
 
 results = []
 
-def processFreeEnergies(nrgs, FILE):
 
+def processFreeEnergies(nrgs, FILE):
     # try to merge the free enegies - this will raise an exception
     # if this object is not a free energy collection
-    nrgs.merge(0,0)
+    nrgs.merge(0, 0)
 
     FILE.write("# Processing object %s\n" % nrgs)
 
@@ -211,7 +227,7 @@ def processFreeEnergies(nrgs, FILE):
     # get the convergence of the free energy
     convergence = {}
 
-    for i in range(1,nits):
+    for i in range(1, nits):
         try:
             convergence[i] = nrgs[i].sum().values()[-1].y()
         except:
@@ -222,23 +238,23 @@ def processFreeEnergies(nrgs, FILE):
 
     # now get the averaged PMF
     if range_start:
-        if range_start > nits-1:
-            start = nits-1
+        if range_start > nits - 1:
+            start = nits - 1
         else:
             start = range_start
 
-        if range_end > nits-1:
-            end = nits-1
+        if range_end > nits - 1:
+            end = nits - 1
         else:
             end = range_end
 
     else:
-        end = nits-1
+        end = nits - 1
         start = end - int(percent * end / 100.0)
 
     FILE.write("# Averaging over iterations %s to %s\n" % (start, end))
 
-    nrg = nrgs.merge(start,end)
+    nrg = nrgs.merge(start, end)
 
     try:
         pmf = nrg.sum()
@@ -246,13 +262,13 @@ def processFreeEnergies(nrgs, FILE):
         pmf = nrg.integrate()
 
     return (name, convergence, pmf)
-    
+
 
 try:
-    results.append( processFreeEnergies(freenrgs, FILE) )
+    results.append(processFreeEnergies(freenrgs, FILE))
 except:
     for freenrg in freenrgs:
-        results.append( processFreeEnergies(freenrg, FILE) )
+        results.append(processFreeEnergies(freenrg, FILE))
 
 FILE.write("# Convergence\n")
 FILE.write("# Iteration \n")
@@ -288,7 +304,8 @@ for result in results:
     FILE.write("# Lambda  PMF  Maximum  Minimum \n")
 
     for value in result[2].values():
-        FILE.write("%s  %s  %s  %s\n" % (value.x(), value.y(), value.y()+value.yMaxError(), value.y()-value.yMaxError()))
+        FILE.write(
+            "%s  %s  %s  %s\n" % (value.x(), value.y(), value.y() + value.yMaxError(), value.y() - value.yMaxError()))
 
 FILE.write("# Free energies \n")
 
@@ -301,7 +318,6 @@ for result in results:
         pass
 
     FILE.write("#\n")
-
 
 if gradient_files:
     cmd = "rm freenrgs.s3"

--- a/wrapper/python/scripts/analyse_freenrg.py
+++ b/wrapper/python/scripts/analyse_freenrg.py
@@ -1,14 +1,23 @@
 description = """
 analyse_freenrg is an analysis app that has been designed to analyse the output of all free energy calculations in Sire. analyse_freenrg reads in a Sire Saved Stream (.s3) file that contains a list of Sire.Analysis free energy objects (e.g. FEP, TI, Bennetts). analyse_freenrg will average and analyse these free energies according the to options you supply, e.g. assuming that the free energies are stored in freenrgs.s3, and you want to average iterations 100-200 from the simulation, and write the results to ‘results.txt’, type;
-sire.app/bin/analyse_freenrg -i freenrgs.s3 -r 100 200 -o results.txt
-Alternatively, if you just want to average over the last 60% of iterations, type;
-sire.app/bin/analyse_freenrg -i freenrgs.s3 -o results.txt
-(you can specify the percentage to average using the ‘--percent’ option)
-analyse_freenrg automatically knows how many free energies are contained in the s3 file, what their types are and what should be done to analyse the results. For example, the waterswap, ligandswap and quantomm apps all output s3 files that contain FEP, Bennetts and TI free energy data, so analyse_freenrg knows automatically to perform FEP, Bennetts and TI analysis on that data and to report all of the results. analyse_freenrg also knows whether or not finite difference approximations have been used, whether forwards and backwards windows were evaluated, the temperature and conditions of the simulation etc. The aim is that it should handle everything for you, so you can concentrate on looking at the potential of mean force (PMF) or final result.
-For FEP data, analyse_freenrg will return the FEP PMF across lambda, together with errors based on statistical convergence (95% standard error) and the difference between forwards and backwards free energies (if available).
-For Bennetts data, analyse_freenrg will return the Bennetts Acceptance Ratio PMF across lambda, with errors based on statistical convergence (95% standard error).
-For TI data, analyse_free energy will return the PMF across lambda based on polynomial fitting of the gradients and analytic integration of the resulting function. It will also return the integral across lambda using simple quadrature. Errors are based on statistical convergence (95% standard error) and on the difference between the forwards and backwards finite difference gradients (if available, and if finite-difference TI was used).
-If you need more help understanding or interpreting the results of an analyse_freenrg analysis then please feel free to get in touch via the Sire users mailing list.
+
+sire.app/bin/analyse_freenrg -i freenrgs.s3 -r 100 200 -o results.txt
+
+Alternatively, if you just want to average over the last 60% of iterations, type;
+
+sire.app/bin/analyse_freenrg -i freenrgs.s3 -o results.txt
+
+(you can specify the percentage to average using the ‘--percent’ option)
+
+analyse_freenrg automatically knows how many free energies are contained in the s3 file, what their types are and what should be done to analyse the results. For example, the waterswap, ligandswap and quantomm apps all output s3 files that contain FEP, Bennetts and TI free energy data, so analyse_freenrg knows automatically to perform FEP, Bennetts and TI analysis on that data and to report all of the results. analyse_freenrg also knows whether or not finite difference approximations have been used, whether forwards and backwards windows were evaluated, the temperature and conditions of the simulation etc. The aim is that it should handle everything for you, so you can concentrate on looking at the potential of mean force (PMF) or final result.
+
+For FEP data, analyse_freenrg will return the FEP PMF across lambda, together with errors based on statistical convergence (95% standard error) and the difference between forwards and backwards free energies (if available).
+
+For Bennetts data, analyse_freenrg will return the Bennetts Acceptance Ratio PMF across lambda, with errors based on statistical convergence (95% standard error).
+
+For TI data, analyse_free energy will return the PMF across lambda based on polynomial fitting of the gradients and analytic integration of the resulting function. It will also return the integral across lambda using simple quadrature. Errors are based on statistical convergence (95% standard error) and on the difference between the forwards and backwards finite difference gradients (if available, and if finite-difference TI was used).
+
+If you need more help understanding or interpreting the results of an analyse_freenrg analysis then please feel free to get in touch via the Sire users mailing list.
 """
 
 from Sire.Analysis import *
@@ -68,8 +77,9 @@ if args.author:
     must_exit = True
 
 if args.version:
-    print("\analyse_freenrg version 0.1")
-    print(Sire.Config.versionString())
+    print("analyse_freenrg -- from Sire release version <%s>" %Sire.__version__)
+    print("This particular release can be downloaded here: "
+          "https://github.com/michellab/Sire/releases/tag/v%s" %Sire.__version__)
     must_exit = True
 
 if must_exit:

--- a/wrapper/python/scripts/analyse_reti.py
+++ b/wrapper/python/scripts/analyse_reti.py
@@ -1,15 +1,19 @@
 description = """
 analyse_reti is an analysis app that has been designed to analyse the replica exchange trajectory of all RETI simulations in Sire. analyse_reti reads in a Sire Saved Stream (.s3) file that contains a Sire simulation restart file (typically called ???_restart.s3). analyse_reti will extract the replica exchange trajectory and print it out in a format that will allow easy graphing. If you want to analyse the replica exchange moves from iterations 100 to 200 from the files restart.s3 and to write the results out to 'results.txt' then type;
-sire.app/bin/analyse_reti -i restart.s3 -r 100 200 -o results.txt
-Alternatively, if you just want to analyse the last 60% of iterations, type;
-sire.app/bin/analyse_reti -i restart.s3 --percent 60 -o results.txt
+
+sire.app/bin/analyse_reti -i restart.s3 -r 100 200 -o results.txt
+
+Alternatively, if you just want to analyse the last 60% of iterations, type;
+
+sire.app/bin/analyse_reti -i restart.s3 --percent 60 -o results.txt
 
 You can also analyse all replica exchange iterations using
 
 sire.app/bin/analyse_reti -i restart.s3 -o results.txt
 
 If you don't supply the name of the output file, then the analysis is printed to the screen.
-If you need more help understanding or interpreting the results of an analyse_reti analysis then please feel free to get in touch via the Sire users mailing list.
+
+If you need more help understanding or interpreting the results of an analyse_reti analysis then please feel free to get in touch via the Sire users mailing list.
 """
 
 import Sire.Stream
@@ -63,8 +67,9 @@ if args.author:
     must_exit = True
 
 if args.version:
-    print("\analyse_reti version 0.1")
-    print(Sire.Config.versionString())
+    print("analyse_reti -- from Sire release version <%s>" %Sire.__version__)
+    print("This particular release can be downloaded here: "
+          "https://github.com/michellab/Sire/releases/tag/v%s" %Sire.__version__)
     must_exit = True
 
 if must_exit:

--- a/wrapper/python/scripts/analyse_reti.py
+++ b/wrapper/python/scripts/analyse_reti.py
@@ -1,5 +1,9 @@
 description = """
-analyse_reti is an analysis app that has been designed to analyse the replica exchange trajectory of all RETI simulations in Sire. analyse_reti reads in a Sire Saved Stream (.s3) file that contains a Sire simulation restart file (typically called ???_restart.s3). analyse_reti will extract the replica exchange trajectory and print it out in a format that will allow easy graphing. If you want to analyse the replica exchange moves from iterations 100 to 200 from the files restart.s3 and to write the results out to 'results.txt' then type;
+analyse_reti is an analysis app that has been designed to analyse the replica exchange trajectory of all RETI
+simulations in Sire. analyse_reti reads in a Sire Saved Stream (.s3) file that contains a Sire simulation restart file
+(typically called ???_restart.s3). analyse_reti will extract the replica exchange trajectory and print it out in a
+format that will allow easy graphing. If you want to analyse the replica exchange moves from iterations 100 to 200 from
+the files restart.s3 and to write the results out to 'results.txt' then type;
 
 sire.app/bin/analyse_reti -i restart.s3 -r 100 200 -o results.txt
 
@@ -13,7 +17,8 @@ sire.app/bin/analyse_reti -i restart.s3 -o results.txt
 
 If you don't supply the name of the output file, then the analysis is printed to the screen.
 
-If you need more help understanding or interpreting the results of an analyse_reti analysis then please feel free to get in touch via the Sire users mailing list.
+If you need more help understanding or interpreting the results of an analyse_reti analysis then please feel free to get
+in touch via the Sire users mailing list, or by creating a github issue.
 """
 
 import Sire.Stream

--- a/wrapper/python/scripts/ligandswap.py
+++ b/wrapper/python/scripts/ligandswap.py
@@ -1,21 +1,38 @@
 description = """
 ligandswap is a method developed and implemented using Sire that allows relative protein-ligand binding free energies to be calculated from first-principles, condensed-phase simulations. The method is currently under development and is not yet published (so use at your own risk!). The method is similar to waterswap, but instead of swapping a ligand with water, ligandswap swaps one ligand with another.
-The method works by constructing a reaction coordinate that swaps one ligand (ligand 0) bound to the protein with another ligand (ligand 1) solvated in water. The affect is to unbind ligand 0 while simultaneously binding ligand 1. To ensure there is no bias towards ligand 0, a second stage calculation is performed which swaps ligand 1 bound to the protein with ligand 0 free in water. This should give the negative of the stage 1 calculation.
-The input files for a ligandswap calculation are the Amber format coordinate and topology files that represent the solvated protein-ligand 0 and protein-ligand 1 complexes (solvated using TIP3P water in a periodic, orthorhombic/cubic box).
-Assuming that these files are called “complex0.crd” and “complex0.top”, and that ligand 0 is called “LIG0”, and “complex1.crd” and “complex1.top”, and that ligand 1 is called “LIG1”, then the command to run a ligandswap simulation is;
-sire.app/bin/ligandswap -c0 complex0.crd -t0 complex0.top -l0 LIG0 -c1 complex1.crd -t1 complex1.top -l1 LIG1
-Sire will run the calculation using a default configuration that should be sufficient for most use cases. If you want to change any of the configuration parameters, then you can do so by writing a configuration file, the help for which can be found by running
-sire.app/bin/ligandswap --help-config
-Once you have written a configuration file, e.g. called “CONFIG”, then you can use it via
-sire.app/bin/ligandswap -c0 complex0.crd -t0 complex0.top -l0 LIG0 -c1 complex1.crd -t1 complex1.top -l1 LIG1 -C config
-As well as calculating relative binding free energies, ligandswap can calculate relative hydration free energies by swapping two ligands between a solvent box and vacuum. To swap to vacuum, use the ‘--vacuum’ option (see ‘--help’).
-Sire will automatically use all of the processor cores available on your compute node. The calculation is not fast, and the free energy averages (collected simultaneously via thermodynamic integration (TI), free energy perturbation (FEP) and Bennetts Acceptance Ratio (BAR) method) will take 1-4 days of compute time to converge. 
-Sire performs the calculation as a series of iterations (1000 by default), with the binding free energy (and binding free energy components) written to an output results file at the end of each iteration. This is performed for each stage (stage 1 being ligand 0 bound to ligand 1 bound, and stage 2 being ligand 1 bound to ligand 0 bound). These files, called output/stageX/results_????.log (where X is the stage number and ???? is the iteration number) can be monitored during the simulation to check for convergence. At the end of the simulation, you can analyse the results of each stage using the Sire app analyse_freenrg, e.g.
-sire.app/bin/analyse_freenrg -i output/stage1/freenrgs.s3 -o stage1_results.txtsire.app/bin/analyse_freenrg -i output/stage2/freenrgs.s3 -o stage2_results.txt
-This will calculate the potentials of mean force (PMFs) from the FEP, TI and BAR averages and will write them all to the files 'stage1_results.txt' and ‘stage2_results.txt’. At the bottom of the results will be four estimates of the relative binding free energy. These four estimates are; estimate from analytic integration of TI, estimate from quadrature based integration of TI, estimate from FEP and estimate from BAR. The relative binding free energy is the average of the four estimates from stage 1, and the negative of the four estimates from stage 2 (stage 2 is the reverse process of stage 1). An error can be approximated by looking at the spread of these values (e.g. by a standard deviation). If the simulation is well-converged, and there is no bias between the different binding modes of ligand 0 and ligand 1, then these eight estimates should be roughly equal.
-In addition to the output/results_????.log files, Sire will also write a restart file (lsrc_restart.s3) and will write all of the free energies into freenrgs_????.s3 files (for the total free energy, and also for the residue/water components and bound and free parts). These .s3 files contain the streamed versions of the Sire objects, and can be used to restart the simulation, or to inspect the free energies or perform statistical analysis (e.g. recalculating the free energies using different integration methods, examining convergence of thermodynamic integration compared to free energy perturbation etc.). Also, Sire can be instructed to write out PDB coordinate files of the intermediates in the calculation, e.g. so you can see how the protein changes conformation as the ligand is exchanged with water. The PDB output files show only the atoms that move during the simulation, so do not worry if you only see a small cutout of your protein.
-While ligandswap aims to calculate the relative binding free energy, it is not magic, and cannot overcome errors in the parameters or model of the complex. ligandswap will only be as accurate as the underlying model of the complex, and as it neglects terms such as polarisability, ionic effects and concentration effects. Care should be taken when interpreting the results of ligandswap, and, ideally, repeat calculations should be performed, e.g. by running on snapshots taken from an equilibrated molecular dynamics simulation.
-If you need more help understanding or interpreting the results of a ligandswap calculation then please feel free to get in touch via the Sire users mailing list.
+
+The method works by constructing a reaction coordinate that swaps one ligand (ligand 0) bound to the protein with another ligand (ligand 1) solvated in water. The affect is to unbind ligand 0 while simultaneously binding ligand 1. To ensure there is no bias towards ligand 0, a second stage calculation is performed which swaps ligand 1 bound to the protein with ligand 0 free in water. This should give the negative of the stage 1 calculation.
+
+The input files for a ligandswap calculation are the Amber format coordinate and topology files that represent the solvated protein-ligand 0 and protein-ligand 1 complexes (solvated using TIP3P water in a periodic, orthorhombic/cubic box).
+
+Assuming that these files are called “complex0.crd” and “complex0.top”, and that ligand 0 is called “LIG0”, and “complex1.crd” and “complex1.top”, and that ligand 1 is called “LIG1”, then the command to run a ligandswap simulation is;
+
+sire.app/bin/ligandswap -c0 complex0.crd -t0 complex0.top -l0 LIG0 -c1 complex1.crd -t1 complex1.top -l1 LIG1
+
+Sire will run the calculation using a default configuration that should be sufficient for most use cases. If you want to change any of the configuration parameters, then you can do so by writing a configuration file, the help for which can be found by running
+
+sire.app/bin/ligandswap --help-config
+
+Once you have written a configuration file, e.g. called “CONFIG”, then you can use it via
+
+sire.app/bin/ligandswap -c0 complex0.crd -t0 complex0.top -l0 LIG0 -c1 complex1.crd -t1 complex1.top -l1 LIG1 -C config
+
+As well as calculating relative binding free energies, ligandswap can calculate relative hydration free energies by swapping two ligands between a solvent box and vacuum. To swap to vacuum, use the ‘--vacuum’ option (see ‘--help’).
+
+Sire will automatically use all of the processor cores available on your compute node. The calculation is not fast, and the free energy averages (collected simultaneously via thermodynamic integration (TI), free energy perturbation (FEP) and Bennetts Acceptance Ratio (BAR) method) will take 1-4 days of compute time to converge. 
+
+Sire performs the calculation as a series of iterations (1000 by default), with the binding free energy (and binding free energy components) written to an output results file at the end of each iteration. This is performed for each stage (stage 1 being ligand 0 bound to ligand 1 bound, and stage 2 being ligand 1 bound to ligand 0 bound). These files, called output/stageX/results_????.log (where X is the stage number and ???? is the iteration number) can be monitored during the simulation to check for convergence. At the end of the simulation, you can analyse the results of each stage using the Sire app analyse_freenrg, e.g.
+
+sire.app/bin/analyse_freenrg -i output/stage1/freenrgs.s3 -o stage1_results.txt
+sire.app/bin/analyse_freenrg -i output/stage2/freenrgs.s3 -o stage2_results.txt
+
+This will calculate the potentials of mean force (PMFs) from the FEP, TI and BAR averages and will write them all to the files 'stage1_results.txt' and ‘stage2_results.txt’. At the bottom of the results will be four estimates of the relative binding free energy. These four estimates are; estimate from analytic integration of TI, estimate from quadrature based integration of TI, estimate from FEP and estimate from BAR. The relative binding free energy is the average of the four estimates from stage 1, and the negative of the four estimates from stage 2 (stage 2 is the reverse process of stage 1). An error can be approximated by looking at the spread of these values (e.g. by a standard deviation). If the simulation is well-converged, and there is no bias between the different binding modes of ligand 0 and ligand 1, then these eight estimates should be roughly equal.
+
+In addition to the output/results_????.log files, Sire will also write a restart file (lsrc_restart.s3) and will write all of the free energies into freenrgs_????.s3 files (for the total free energy, and also for the residue/water components and bound and free parts). These .s3 files contain the streamed versions of the Sire objects, and can be used to restart the simulation, or to inspect the free energies or perform statistical analysis (e.g. recalculating the free energies using different integration methods, examining convergence of thermodynamic integration compared to free energy perturbation etc.). Also, Sire can be instructed to write out PDB coordinate files of the intermediates in the calculation, e.g. so you can see how the protein changes conformation as the ligand is exchanged with water. The PDB output files show only the atoms that move during the simulation, so do not worry if you only see a small cutout of your protein.
+
+While ligandswap aims to calculate the relative binding free energy, it is not magic, and cannot overcome errors in the parameters or model of the complex. ligandswap will only be as accurate as the underlying model of the complex, and as it neglects terms such as polarisability, ionic effects and concentration effects. Care should be taken when interpreting the results of ligandswap, and, ideally, repeat calculations should be performed, e.g. by running on snapshots taken from an equilibrated molecular dynamics simulation.
+
+If you need more help understanding or interpreting the results of a ligandswap calculation then please feel free to get in touch via the Sire users mailing list.
 """
 
 from Sire.Tools import LSRC
@@ -103,8 +120,9 @@ if args.author:
     must_exit = True
 
 if args.version:
-    print("\ligandswap version 0.2")
-    print(Sire.Config.versionString())
+    print("ligandswap -- from Sire release version <%s>" %Sire.__version__)
+    print("This particular release can be downloaded here: "
+          "https://github.com/michellab/Sire/releases/tag/v%s" %Sire.__version__)
     must_exit = True
 
 if args.help_config:

--- a/wrapper/python/scripts/ligandswap.py
+++ b/wrapper/python/scripts/ligandswap.py
@@ -1,15 +1,25 @@
 description = """
-ligandswap is a method developed and implemented using Sire that allows relative protein-ligand binding free energies to be calculated from first-principles, condensed-phase simulations. The method is currently under development and is not yet published (so use at your own risk!). The method is similar to waterswap, but instead of swapping a ligand with water, ligandswap swaps one ligand with another.
+ligandswap is a method developed and implemented using Sire that allows relative protein-ligand binding free energies to
+ be calculated from first-principles, condensed-phase simulations. The method is currently under development and is not
+ yet published (so use at your own risk!). The method is similar to waterswap, but instead of swapping a ligand with
+ water, ligandswap swaps one ligand with another.
 
-The method works by constructing a reaction coordinate that swaps one ligand (ligand 0) bound to the protein with another ligand (ligand 1) solvated in water. The affect is to unbind ligand 0 while simultaneously binding ligand 1. To ensure there is no bias towards ligand 0, a second stage calculation is performed which swaps ligand 1 bound to the protein with ligand 0 free in water. This should give the negative of the stage 1 calculation.
+The method works by constructing a reaction coordinate that swaps one ligand (ligand 0) bound to the protein with
+another ligand (ligand 1) solvated in water. The affect is to unbind ligand 0 while simultaneously binding ligand 1. To
+ensure there is no bias towards ligand 0, a second stage calculation is performed which swaps ligand 1 bound to the
+protein with ligand 0 free in water. This should give the negative of the stage 1 calculation.
 
-The input files for a ligandswap calculation are the Amber format coordinate and topology files that represent the solvated protein-ligand 0 and protein-ligand 1 complexes (solvated using TIP3P water in a periodic, orthorhombic/cubic box).
+The input files for a ligandswap calculation are the Amber format coordinate and topology files that represent the
+solvated protein-ligand 0 and protein-ligand 1 complexes (solvated using TIP3P water in a periodic, orthorhombic/cubic box).
 
-Assuming that these files are called “complex0.crd” and “complex0.top”, and that ligand 0 is called “LIG0”, and “complex1.crd” and “complex1.top”, and that ligand 1 is called “LIG1”, then the command to run a ligandswap simulation is;
+Assuming that these files are called “complex0.crd” and “complex0.top”, and that ligand 0 is called “LIG0”, and
+“complex1.crd” and “complex1.top”, and that ligand 1 is called “LIG1”, then the command to run a ligandswap simulation is;
 
 sire.app/bin/ligandswap -c0 complex0.crd -t0 complex0.top -l0 LIG0 -c1 complex1.crd -t1 complex1.top -l1 LIG1
 
-Sire will run the calculation using a default configuration that should be sufficient for most use cases. If you want to change any of the configuration parameters, then you can do so by writing a configuration file, the help for which can be found by running
+Sire will run the calculation using a default configuration that should be sufficient for most use cases. If you want
+to change any of the configuration parameters, then you can do so by writing a configuration file, the help for which
+can be found by running
 
 sire.app/bin/ligandswap --help-config
 
@@ -17,22 +27,50 @@ Once you have written a configuration file, e.g. called “CONFIG”, then you c
 
 sire.app/bin/ligandswap -c0 complex0.crd -t0 complex0.top -l0 LIG0 -c1 complex1.crd -t1 complex1.top -l1 LIG1 -C config
 
-As well as calculating relative binding free energies, ligandswap can calculate relative hydration free energies by swapping two ligands between a solvent box and vacuum. To swap to vacuum, use the ‘--vacuum’ option (see ‘--help’).
+As well as calculating relative binding free energies, ligandswap can calculate relative hydration free energies by
+swapping two ligands between a solvent box and vacuum. To swap to vacuum, use the ‘--vacuum’ option (see ‘--help’).
 
-Sire will automatically use all of the processor cores available on your compute node. The calculation is not fast, and the free energy averages (collected simultaneously via thermodynamic integration (TI), free energy perturbation (FEP) and Bennetts Acceptance Ratio (BAR) method) will take 1-4 days of compute time to converge. 
+Sire will automatically use all of the processor cores available on your compute node. The calculation is not fast,
+and the free energy averages (collected simultaneously via thermodynamic integration (TI), free energy perturbation
+(FEP) and Bennetts Acceptance Ratio (BAR) method) will take 1-4 days of compute time to converge.
 
-Sire performs the calculation as a series of iterations (1000 by default), with the binding free energy (and binding free energy components) written to an output results file at the end of each iteration. This is performed for each stage (stage 1 being ligand 0 bound to ligand 1 bound, and stage 2 being ligand 1 bound to ligand 0 bound). These files, called output/stageX/results_????.log (where X is the stage number and ???? is the iteration number) can be monitored during the simulation to check for convergence. At the end of the simulation, you can analyse the results of each stage using the Sire app analyse_freenrg, e.g.
+Sire performs the calculation as a series of iterations (1000 by default), with the binding free energy
+(and binding free energy components) written to an output results file at the end of each iteration. This is performed
+for each stage (stage 1 being ligand 0 bound to ligand 1 bound, and stage 2 being ligand 1 bound to ligand 0 bound).
+These files, called output/stageX/results_????.log (where X is the stage number and ???? is the iteration number) can
+be monitored during the simulation to check for convergence. At the end of the simulation, you can analyse the results
+of each stage using the Sire app analyse_freenrg, e.g.
 
 sire.app/bin/analyse_freenrg -i output/stage1/freenrgs.s3 -o stage1_results.txt
 sire.app/bin/analyse_freenrg -i output/stage2/freenrgs.s3 -o stage2_results.txt
 
-This will calculate the potentials of mean force (PMFs) from the FEP, TI and BAR averages and will write them all to the files 'stage1_results.txt' and ‘stage2_results.txt’. At the bottom of the results will be four estimates of the relative binding free energy. These four estimates are; estimate from analytic integration of TI, estimate from quadrature based integration of TI, estimate from FEP and estimate from BAR. The relative binding free energy is the average of the four estimates from stage 1, and the negative of the four estimates from stage 2 (stage 2 is the reverse process of stage 1). An error can be approximated by looking at the spread of these values (e.g. by a standard deviation). If the simulation is well-converged, and there is no bias between the different binding modes of ligand 0 and ligand 1, then these eight estimates should be roughly equal.
+This will calculate the potentials of mean force (PMFs) from the FEP, TI and BAR averages and will write them all to
+the files 'stage1_results.txt' and ‘stage2_results.txt’. At the bottom of the results will be four estimates of the
+relative binding free energy. These four estimates are; estimate from analytic integration of TI, estimate from
+quadrature based integration of TI, estimate from FEP and estimate from BAR. The relative binding free energy is the
+average of the four estimates from stage 1, and the negative of the four estimates from stage 2 (stage 2 is the reverse
+process of stage 1). An error can be approximated by looking at the spread of these values (e.g. by a standard
+deviation). If the simulation is well-converged, and there is no bias between the different binding modes of ligand 0
+and ligand 1, then these eight estimates should be roughly equal.
 
-In addition to the output/results_????.log files, Sire will also write a restart file (lsrc_restart.s3) and will write all of the free energies into freenrgs_????.s3 files (for the total free energy, and also for the residue/water components and bound and free parts). These .s3 files contain the streamed versions of the Sire objects, and can be used to restart the simulation, or to inspect the free energies or perform statistical analysis (e.g. recalculating the free energies using different integration methods, examining convergence of thermodynamic integration compared to free energy perturbation etc.). Also, Sire can be instructed to write out PDB coordinate files of the intermediates in the calculation, e.g. so you can see how the protein changes conformation as the ligand is exchanged with water. The PDB output files show only the atoms that move during the simulation, so do not worry if you only see a small cutout of your protein.
+In addition to the output/results_????.log files, Sire will also write a restart file (lsrc_restart.s3) and will write
+all of the free energies into freenrgs_????.s3 files (for the total free energy, and also for the residue/water
+components and bound and free parts). These .s3 files contain the streamed versions of the Sire objects, and can be
+used to restart the simulation, or to inspect the free energies or perform statistical analysis (e.g. recalculating the
+free energies using different integration methods, examining convergence of thermodynamic integration compared to free
+energy perturbation etc.). Also, Sire can be instructed to write out PDB coordinate files of the intermediates in the
+calculation, e.g. so you can see how the protein changes conformation as the ligand is exchanged with water. The PDB
+output files show only the atoms that move during the simulation, so do not worry if you only see a small cutout of
+your protein.
 
-While ligandswap aims to calculate the relative binding free energy, it is not magic, and cannot overcome errors in the parameters or model of the complex. ligandswap will only be as accurate as the underlying model of the complex, and as it neglects terms such as polarisability, ionic effects and concentration effects. Care should be taken when interpreting the results of ligandswap, and, ideally, repeat calculations should be performed, e.g. by running on snapshots taken from an equilibrated molecular dynamics simulation.
+While ligandswap aims to calculate the relative binding free energy, it is not magic, and cannot overcome errors in the
+parameters or model of the complex. ligandswap will only be as accurate as the underlying model of the complex, and as
+it neglects terms such as polarisability, ionic effects and concentration effects. Care should be taken when
+interpreting the results of ligandswap, and, ideally, repeat calculations should be performed, e.g. by running on
+snapshots taken from an equilibrated molecular dynamics simulation.
 
-If you need more help understanding or interpreting the results of a ligandswap calculation then please feel free to get in touch via the Sire users mailing list.
+If you need more help understanding or interpreting the results of a ligandswap calculation then please feel free to
+get in touch via the Sire users mailing list, or by creating a github issue.
 """
 
 from Sire.Tools import LSRC

--- a/wrapper/python/scripts/nautilus-avggrids.py
+++ b/wrapper/python/scripts/nautilus-avggrids.py
@@ -41,8 +41,9 @@ if args.author:
     must_exit = True
 
 if args.version:
-    print("\n nautilus-avggrids version 1.0")
-    #print(Sire.Config.versionString())
+    print("nautilus-avggrids -- from Sire release version <%s>" %Sire.__version__)
+    print("This particular release can be downloaded here: "
+          "https://github.com/michellab/Sire/releases/tag/v%s" %Sire.__version__)
     must_exit = True
 
 if must_exit:

--- a/wrapper/python/scripts/nautilus-boxgrid.py
+++ b/wrapper/python/scripts/nautilus-boxgrid.py
@@ -49,8 +49,9 @@ if args.author:
     must_exit = True
 
 if args.version:
-    print("\n nautilus-boxgrid version 0.1")
-    #print(Sire.Config.versionString())
+    print("nautilus-boxgrid -- from Sire release version <%s>" %Sire.__version__)
+    print("This particular release can be downloaded here: "
+          "https://github.com/michellab/Sire/releases/tag/v%s" %Sire.__version__)
     must_exit = True
 
 if must_exit:

--- a/wrapper/python/scripts/nautilus-cell2grid.py
+++ b/wrapper/python/scripts/nautilus-cell2grid.py
@@ -46,8 +46,9 @@ if args.author:
     must_exit = True
 
 if args.version:
-    print("\n nautilus-cell2grid version 1.0")
-    #print(Sire.Config.versionString())
+    print("nautilus-cell2grid -- from Sire release version <%s>" %Sire.__version__)
+    print("This particular release can be downloaded here: "
+          "https://github.com/michellab/Sire/releases/tag/v%s" %Sire.__version__)
     must_exit = True
 
 if must_exit:

--- a/wrapper/python/scripts/nautilus-clustergrids.py
+++ b/wrapper/python/scripts/nautilus-clustergrids.py
@@ -46,8 +46,9 @@ if args.author:
     must_exit = True
 
 if args.version:
-    print("\n nautilus-clustergrids version 1.0")
-    #print(Sire.Config.versionString())
+    print("nautilus-clustergrids -- from Sire release version <%s>" %Sire.__version__)
+    print("This particular release can be downloaded here: "
+          "https://github.com/michellab/Sire/releases/tag/v%s" %Sire.__version__)
     must_exit = True
 
 if must_exit:

--- a/wrapper/python/scripts/nautilus-focusgrid.py
+++ b/wrapper/python/scripts/nautilus-focusgrid.py
@@ -50,8 +50,9 @@ if args.author:
     must_exit = True
 
 if args.version:
-    print("\n nautilus-focusgrid version 0.1")
-    #print(Sire.Config.versionString())
+    print("nautilus-focusgrids -- from Sire release version <%s>" %Sire.__version__)
+    print("This particular release can be downloaded here: "
+          "https://github.com/michellab/Sire/releases/tag/v%s" %Sire.__version__)
     must_exit = True
 
 if must_exit:

--- a/wrapper/python/scripts/nautilus-protocol.py
+++ b/wrapper/python/scripts/nautilus-protocol.py
@@ -38,8 +38,9 @@ if args.author:
     must_exit = True
 
 if args.version:
-    print("\n nautilus-protocol version 1.0")
-    #print(Sire.Config.versionString())
+    print("nautilus-protocol -- from Sire release version <%s>" %Sire.__version__)
+    print("This particular release can be downloaded here: "
+          "https://github.com/michellab/Sire/releases/tag/v%s" %Sire.__version__)
     must_exit = True
 
 if must_exit:

--- a/wrapper/python/scripts/nautilus-regionproperties.py
+++ b/wrapper/python/scripts/nautilus-regionproperties.py
@@ -40,8 +40,9 @@ if args.author:
     must_exit = True
 
 if args.version:
-    print("\n nautilus-regionproperties version 1.0")
-    #print(Sire.Config.versionString())
+    print("nautilus-regionproperties -- from Sire release version <%s>" %Sire.__version__)
+    print("This particular release can be downloaded here: "
+          "https://github.com/michellab/Sire/releases/tag/v%s" %Sire.__version__)
     must_exit = True
 
 if must_exit:

--- a/wrapper/python/scripts/nautilus-subgrids.py
+++ b/wrapper/python/scripts/nautilus-subgrids.py
@@ -43,8 +43,9 @@ if args.author:
     must_exit = True
 
 if args.version:
-    print("\n nautilus-subgrids version 1.0")
-    #print(Sire.Config.versionString())
+    print("nautilus-subgrids -- from Sire release version <%s>" %Sire.__version__)
+    print("This particular release can be downloaded here: "
+          "https://github.com/michellab/Sire/releases/tag/v%s" %Sire.__version__)
     must_exit = True
 
 if must_exit:

--- a/wrapper/python/scripts/nautilus-traj2cell.py
+++ b/wrapper/python/scripts/nautilus-traj2cell.py
@@ -53,8 +53,9 @@ if args.author:
     must_exit = True
 
 if args.version:
-    print("\nautilus-traj2cell version 1.0")
-    #print(Sire.Config.versionString())
+    print("nautilus-traj2cell -- from Sire release version <%s>" %Sire.__version__)
+    print("This particular release can be downloaded here: "
+          "https://github.com/michellab/Sire/releases/tag/v%s" %Sire.__version__)
     must_exit = True
 
 if must_exit:

--- a/wrapper/python/scripts/quantomm.py
+++ b/wrapper/python/scripts/quantomm.py
@@ -1,19 +1,33 @@
 description = """
-quantomm (QUANTum TO MM) is a program based on a method developed and implemented using Sire that calculates the difference in free energy between a quantom mechanics (QM) and molecular mechanics (MM) model of a molecule, using first-principles, condensed-phase Monte Carlo simulations. The method is described in;
+quantomm (QUANTum TO MM) is a program based on a method developed and implemented using Sire that calculates the
+difference in free energy between a quantom mechanics (QM) and molecular mechanics (MM) model of a molecule, using
+first-principles, condensed-phase Monte Carlo simulations. The method is described in;
 
-Woods, C.J., Manby F.R., Mulholland A.J., “An efﬁcient method for the calculation of quantum mechanics/molecular mechanics free energies”, J. Phys. Chem., 128, 014109, 2008, doi:10.1063/1.2805379
+Woods, C.J., Manby F.R., Mulholland A.J., “An efﬁcient method for the calculation of quantum mechanics/molecular
+mechanics free energies”, J. Phys. Chem., 128, 014109, 2008, doi:10.1063/1.2805379
 
-Shaw, K. E., Woods, C. J., Mulholland, A. J., "Compatibility of Quantum Chemical Methods and Empirical (MM) Water Models in Quantum Mechanics / Molecular Mechanics Liquid Water Simulations", J. Phys. Chem. Lett., 1, 219-223, 2010, doi:10.1021/jz900096p
+Shaw, K. E., Woods, C. J., Mulholland, A. J., "Compatibility of Quantum Chemical Methods and Empirical (MM) Water
+Models in Quantum Mechanics / Molecular Mechanics Liquid Water Simulations", J. Phys. Chem. Lett., 1, 219-223, 2010,
+doi:10.1021/jz900096p
 
-The method works by constructing a reaction coordinate (lambda) that swaps a quantum mechanics model of the molecule with a molecular mechanics model. At lambda=0, you have a QM molecule, while at lambda=1 you have an MM molecule. Monte Carlo simulations are performed across lambda to calculate the free energy difference between lambda=0 (QM) and lambda=1 (MM).
+The method works by constructing a reaction coordinate (lambda) that swaps a quantum mechanics model of the molecule
+with a molecular mechanics model. At lambda=0, you have a QM molecule, while at lambda=1 you have an MM molecule. Monte
+Carlo simulations are performed across lambda to calculate the free energy difference between lambda=0 (QM) and
+lambda=1 (MM).
 
-The input files for a quantomm calculation are the Amber format coordinate and topology files that hold the molecule to be simulated. Typically, quantomm will be used to turn an MM-calculated binding or solvation free energy into a QM/MM binding or solvation free energy, so you should use the same Amber-format input files for the quantomm job that you used for the binding or solvation simulations.
+The input files for a quantomm calculation are the Amber format coordinate and topology files that hold the molecule
+to be simulated. Typically, quantomm will be used to turn an MM-calculated binding or solvation free energy into a
+QM/MM binding or solvation free energy, so you should use the same Amber-format input files for the quantomm job that
+you used for the binding or solvation simulations.
 
-Assuming that these files are called “system.crd” and “system.top”, and that the molecule to be converted from QM to MM contains a residue called “LIG”, then the command to run a quantomm simulation is;
+Assuming that these files are called “system.crd” and “system.top”, and that the molecule to be converted from QM to
+MM contains a residue called “LIG”, then the command to run a quantomm simulation is;
 
 sire.app/bin/quantomm -c system.crd -t system.top -l LIG 
 
-Sire will run the calculation using a default configuration that should be sufficient for most use cases. There are additional options on the command line that you can use to specify the QM method and basis set (see ‘quantomm --help’). You can also change more advanced configuration parameters using a config file, the help for which can be found by running
+Sire will run the calculation using a default configuration that should be sufficient for most use cases. There are
+additional options on the command line that you can use to specify the QM method and basis set (see ‘quantomm --help’).
+You can also change more advanced configuration parameters using a config file, the help for which can be found by running
 
 sire.app/bin/quantomm --help-config
 
@@ -21,27 +35,59 @@ Once you have written a configuration file, e.g. called “CONFIG”, then you c
 
 sire.app/bin/quantomm -c system.crd -t system.top -l LIG -C config
 
-Sire will automatically use all of the processor cores available on your compute node. The calculation is not fast, and the free energy averages (collected simultaneously via thermodynamic integration (TI), free energy perturbation (FEP) and Bennetts Acceptance Ratio (BAR) method) will take a long time to converge. The simulation speed will depend on the speed of the underlying QM calculation. This is performed using either the "SQM" QM package distributed free with AmberTools (for semiempirical or DFTB calculations), or the “molpro” QM package (for ab-initio calculations), which you must download, license and install separately. Sire will look for "sqm" in $AMBERHOME/bin, and will look for “molpro” in your PATH. If they are not there, then use the “qm executable” option in the CONFIG file to specify the exact path to the molpro executable. If you are using "sqm", you must make sure that you have set the AMBERHOME environmental variable correctly to point to your Amber / AmberTools installation. By default, quantomm will use SQM.
+Sire will automatically use all of the processor cores available on your compute node. The calculation is not fast, and
+the free energy averages (collected simultaneously via thermodynamic integration (TI), free energy perturbation (FEP)
+and Bennetts Acceptance Ratio (BAR) method) will take a long time to converge. The simulation speed will depend on the
+speed of the underlying QM calculation. This is performed using either the "SQM" QM package distributed free with
+AmberTools (for semiempirical or DFTB calculations), or the “molpro” QM package (for ab-initio calculations), which you
+must download, license and install separately. Sire will look for "sqm" in $AMBERHOME/bin, and will look for “molpro”
+in your PATH. If they are not there, then use the “qm executable” option in the CONFIG file to specify the exact path
+to the molpro executable. If you are using "sqm", you must make sure that you have set the AMBERHOME environmental
+variable correctly to point to your Amber / AmberTools installation. By default, quantomm will use SQM.
 
-The calculation will, by default, use QM to model both the intramolecular and intermolecular energy of the QM atoms. This can cause problems, as sometimes bond lengths and angles for the QM model are slightly different to those of the MM model, leading to large differences between the QM and MM energies, and thus a low acceptance probability for the moves. To solve this, and to simplify the calculation, you can use QM to model only the electrostatic interaction energy between the QM and MM atoms. To do this, use the "--intermolecular-only" option, e.g.,
+The calculation will, by default, use QM to model both the intramolecular and intermolecular energy of the QM atoms.
+This can cause problems, as sometimes bond lengths and angles for the QM model are slightly different to those of the
+MM model, leading to large differences between the QM and MM energies, and thus a low acceptance probability for the
+moves. To solve this, and to simplify the calculation, you can use QM to model only the electrostatic interaction
+energy between the QM and MM atoms. To do this, use the "--intermolecular-only" option, e.g.,
 
 sire.app/bin/quantomm -c system.crd -t system.top -l LIG --intermolecular-only
 
-Also, as MM charges include implicit polarisation, you may want to scale the MM charges in the QM/MM calculation by a set scaling factor. You can do this using the "--scale-charges" option, e.g. to scale MM charges by 0.8 use;
+Also, as MM charges include implicit polarisation, you may want to scale the MM charges in the QM/MM calculation by a
+set scaling factor. You can do this using the "--scale-charges" option, e.g. to scale MM charges by 0.8 use;
 
 sire.app/bin/quantomm -c system.crd -t system.top -l LIG --scale-charges 0.8
 
-Sire performs the calculation as a series of iterations (200 by default), with the correction free energy written to an output results file at the end of each iteration. These files, called output/results_????.log (where ???? is the iteration number) can be monitored during the simulation to check for convergence. At the end of the simulation, you can analyse the results of the calculation using the Sire app analyse_freenrg, e.g.
+Sire performs the calculation as a series of iterations (200 by default), with the correction free energy written to
+an output results file at the end of each iteration. These files, called output/results_????.log (where ???? is the
+iteration number) can be monitored during the simulation to check for convergence. At the end of the simulation, you
+can analyse the results of the calculation using the Sire app analyse_freenrg, e.g.
 
 sire.app/bin/analyse_freenrg -i output/freenrgs.s3 -o results.txt
 
-This will calculate the potentials of mean force (PMFs) from the FEP, TI and BAR averages and will write them all to the file 'results.txt'. At the bottom of the results will be four estimates of the correction free energy. These four estimates are; estimate from analytic integration of TI, estimate from quadrature based integration of TI, estimate from FEP and estimate from BAR. The correction free energy is the average of these four estimates, while an error can be approximated by looking at the spread of these values (e.g. by a standard deviation). If the simulation is well-converged, then these four estimates should be roughly equal. Note that this correction free energy is the difference between the MM and QM models, with a fixed offset to account for the difference in ‘zero’ between the MM and QM models. To get the complete correction free energy, you must add this offset back onto the difference (the offset is printed out at the beginning of the simulation).
+This will calculate the potentials of mean force (PMFs) from the FEP, TI and BAR averages and will write them all to
+the file 'results.txt'. At the bottom of the results will be four estimates of the correction free energy. These four
+estimates are; estimate from analytic integration of TI, estimate from quadrature based integration of TI, estimate
+from FEP and estimate from BAR. The correction free energy is the average of these four estimates, while an error can
+be approximated by looking at the spread of these values (e.g. by a standard deviation). If the simulation is
+well-converged, then these four estimates should be roughly equal. Note that this correction free energy is the
+difference between the MM and QM models, with a fixed offset to account for the difference in ‘zero’ between the MM
+and QM models. To get the complete correction free energy, you must add this offset back onto the difference (the
+offset is printed out at the beginning of the simulation).
 
-In addition to the output/results_????.log files, Sire will also write a restart file (quantomm_restart.s3). This .s3 file contains the streamed versions of the Sire objects, and can be used to restart the simulation. Also, Sire can be instructed to write out PDB coordinate files of the intermediates in the calculation, e.g. so you can see how the molecule changes conformation as it moves from QM to MM. The PDB output files show only the atoms that move during the simulation, so do not worry if you only see a small cutout of the system.
+In addition to the output/results_????.log files, Sire will also write a restart file (quantomm_restart.s3). This .s3
+file contains the streamed versions of the Sire objects, and can be used to restart the simulation. Also, Sire can be
+instructed to write out PDB coordinate files of the intermediates in the calculation, e.g. so you can see how the
+molecule changes conformation as it moves from QM to MM. The PDB output files show only the atoms that move during the
+simulation, so do not worry if you only see a small cutout of the system.
 
-While quantomm aims to calculate the correction free energy, it is not magic, and cannot overcome errors in the parameters or model of the system. Care should be taken when interpreting the results of quantomm, and, ideally, repeat calculations should be performed, e.g. by running on snapshots taken from an equilibrated molecular dynamics simulation.
+While quantomm aims to calculate the correction free energy, it is not magic, and cannot overcome errors in the
+parameters or model of the system. Care should be taken when interpreting the results of quantomm, and, ideally,
+repeat calculations should be performed, e.g. by running on snapshots taken from an equilibrated molecular dynamics
+simulation.
 
-If you need more help understanding or interpreting the results of a quantomm calculation then please feel free to get in touch via the Sire users mailing list.
+If you need more help understanding or interpreting the results of a quantomm calculation then please feel free to get
+in touch via the Sire users mailing list.
 """
 
 from Sire.Tools import QuantumToMM

--- a/wrapper/python/scripts/quantomm.py
+++ b/wrapper/python/scripts/quantomm.py
@@ -1,16 +1,27 @@
 description = """
 quantomm (QUANTum TO MM) is a program based on a method developed and implemented using Sire that calculates the difference in free energy between a quantom mechanics (QM) and molecular mechanics (MM) model of a molecule, using first-principles, condensed-phase Monte Carlo simulations. The method is described in;
-Woods, C.J., Manby F.R., Mulholland A.J., “An efﬁcient method for the calculation of quantum mechanics/molecular mechanics free energies”, J. Phys. Chem., 128, 014109, 2008, doi:10.1063/1.2805379
-Shaw, K. E., Woods, C. J., Mulholland, A. J., "Compatibility of Quantum Chemical Methods and Empirical (MM) Water Models in Quantum Mechanics / Molecular Mechanics Liquid Water Simulations", J. Phys. Chem. Lett., 1, 219-223, 2010, doi:10.1021/jz900096p
-The method works by constructing a reaction coordinate (lambda) that swaps a quantum mechanics model of the molecule with a molecular mechanics model. At lambda=0, you have a QM molecule, while at lambda=1 you have an MM molecule. Monte Carlo simulations are performed across lambda to calculate the free energy difference between lambda=0 (QM) and lambda=1 (MM).
-The input files for a quantomm calculation are the Amber format coordinate and topology files that hold the molecule to be simulated. Typically, quantomm will be used to turn an MM-calculated binding or solvation free energy into a QM/MM binding or solvation free energy, so you should use the same Amber-format input files for the quantomm job that you used for the binding or solvation simulations.
-Assuming that these files are called “system.crd” and “system.top”, and that the molecule to be converted from QM to MM contains a residue called “LIG”, then the command to run a quantomm simulation is;
-sire.app/bin/quantomm -c system.crd -t system.top -l LIG 
-Sire will run the calculation using a default configuration that should be sufficient for most use cases. There are additional options on the command line that you can use to specify the QM method and basis set (see ‘quantomm --help’). You can also change more advanced configuration parameters using a config file, the help for which can be found by running
-sire.app/bin/quantomm --help-config
-Once you have written a configuration file, e.g. called “CONFIG”, then you can use it via
-sire.app/bin/quantomm -c system.crd -t system.top -l LIG -C config
-Sire will automatically use all of the processor cores available on your compute node. The calculation is not fast, and the free energy averages (collected simultaneously via thermodynamic integration (TI), free energy perturbation (FEP) and Bennetts Acceptance Ratio (BAR) method) will take a long time to converge. The simulation speed will depend on the speed of the underlying QM calculation. This is performed using either the "SQM" QM package distributed free with AmberTools (for semiempirical or DFTB calculations), or the “molpro” QM package (for ab-initio calculations), which you must download, license and install separately. Sire will look for "sqm" in $AMBERHOME/bin, and will look for “molpro” in your PATH. If they are not there, then use the “qm executable” option in the CONFIG file to specify the exact path to the molpro executable. If you are using "sqm", you must make sure that you have set the AMBERHOME environmental variable correctly to point to your Amber / AmberTools installation. By default, quantomm will use SQM.
+
+Woods, C.J., Manby F.R., Mulholland A.J., “An efﬁcient method for the calculation of quantum mechanics/molecular mechanics free energies”, J. Phys. Chem., 128, 014109, 2008, doi:10.1063/1.2805379
+
+Shaw, K. E., Woods, C. J., Mulholland, A. J., "Compatibility of Quantum Chemical Methods and Empirical (MM) Water Models in Quantum Mechanics / Molecular Mechanics Liquid Water Simulations", J. Phys. Chem. Lett., 1, 219-223, 2010, doi:10.1021/jz900096p
+
+The method works by constructing a reaction coordinate (lambda) that swaps a quantum mechanics model of the molecule with a molecular mechanics model. At lambda=0, you have a QM molecule, while at lambda=1 you have an MM molecule. Monte Carlo simulations are performed across lambda to calculate the free energy difference between lambda=0 (QM) and lambda=1 (MM).
+
+The input files for a quantomm calculation are the Amber format coordinate and topology files that hold the molecule to be simulated. Typically, quantomm will be used to turn an MM-calculated binding or solvation free energy into a QM/MM binding or solvation free energy, so you should use the same Amber-format input files for the quantomm job that you used for the binding or solvation simulations.
+
+Assuming that these files are called “system.crd” and “system.top”, and that the molecule to be converted from QM to MM contains a residue called “LIG”, then the command to run a quantomm simulation is;
+
+sire.app/bin/quantomm -c system.crd -t system.top -l LIG 
+
+Sire will run the calculation using a default configuration that should be sufficient for most use cases. There are additional options on the command line that you can use to specify the QM method and basis set (see ‘quantomm --help’). You can also change more advanced configuration parameters using a config file, the help for which can be found by running
+
+sire.app/bin/quantomm --help-config
+
+Once you have written a configuration file, e.g. called “CONFIG”, then you can use it via
+
+sire.app/bin/quantomm -c system.crd -t system.top -l LIG -C config
+
+Sire will automatically use all of the processor cores available on your compute node. The calculation is not fast, and the free energy averages (collected simultaneously via thermodynamic integration (TI), free energy perturbation (FEP) and Bennetts Acceptance Ratio (BAR) method) will take a long time to converge. The simulation speed will depend on the speed of the underlying QM calculation. This is performed using either the "SQM" QM package distributed free with AmberTools (for semiempirical or DFTB calculations), or the “molpro” QM package (for ab-initio calculations), which you must download, license and install separately. Sire will look for "sqm" in $AMBERHOME/bin, and will look for “molpro” in your PATH. If they are not there, then use the “qm executable” option in the CONFIG file to specify the exact path to the molpro executable. If you are using "sqm", you must make sure that you have set the AMBERHOME environmental variable correctly to point to your Amber / AmberTools installation. By default, quantomm will use SQM.
 
 The calculation will, by default, use QM to model both the intramolecular and intermolecular energy of the QM atoms. This can cause problems, as sometimes bond lengths and angles for the QM model are slightly different to those of the MM model, leading to large differences between the QM and MM energies, and thus a low acceptance probability for the moves. To solve this, and to simplify the calculation, you can use QM to model only the electrostatic interaction energy between the QM and MM atoms. To do this, use the "--intermolecular-only" option, e.g.,
 
@@ -19,12 +30,18 @@ sire.app/bin/quantomm -c system.crd -t system.top -l LIG --intermolecular-only
 Also, as MM charges include implicit polarisation, you may want to scale the MM charges in the QM/MM calculation by a set scaling factor. You can do this using the "--scale-charges" option, e.g. to scale MM charges by 0.8 use;
 
 sire.app/bin/quantomm -c system.crd -t system.top -l LIG --scale-charges 0.8
-Sire performs the calculation as a series of iterations (200 by default), with the correction free energy written to an output results file at the end of each iteration. These files, called output/results_????.log (where ???? is the iteration number) can be monitored during the simulation to check for convergence. At the end of the simulation, you can analyse the results of the calculation using the Sire app analyse_freenrg, e.g.
-sire.app/bin/analyse_freenrg -i output/freenrgs.s3 -o results.txt
-This will calculate the potentials of mean force (PMFs) from the FEP, TI and BAR averages and will write them all to the file 'results.txt'. At the bottom of the results will be four estimates of the correction free energy. These four estimates are; estimate from analytic integration of TI, estimate from quadrature based integration of TI, estimate from FEP and estimate from BAR. The correction free energy is the average of these four estimates, while an error can be approximated by looking at the spread of these values (e.g. by a standard deviation). If the simulation is well-converged, then these four estimates should be roughly equal. Note that this correction free energy is the difference between the MM and QM models, with a fixed offset to account for the difference in ‘zero’ between the MM and QM models. To get the complete correction free energy, you must add this offset back onto the difference (the offset is printed out at the beginning of the simulation).
-In addition to the output/results_????.log files, Sire will also write a restart file (quantomm_restart.s3). This .s3 file contains the streamed versions of the Sire objects, and can be used to restart the simulation. Also, Sire can be instructed to write out PDB coordinate files of the intermediates in the calculation, e.g. so you can see how the molecule changes conformation as it moves from QM to MM. The PDB output files show only the atoms that move during the simulation, so do not worry if you only see a small cutout of the system.
-While quantomm aims to calculate the correction free energy, it is not magic, and cannot overcome errors in the parameters or model of the system. Care should be taken when interpreting the results of quantomm, and, ideally, repeat calculations should be performed, e.g. by running on snapshots taken from an equilibrated molecular dynamics simulation.
-If you need more help understanding or interpreting the results of a quantomm calculation then please feel free to get in touch via the Sire users mailing list.
+
+Sire performs the calculation as a series of iterations (200 by default), with the correction free energy written to an output results file at the end of each iteration. These files, called output/results_????.log (where ???? is the iteration number) can be monitored during the simulation to check for convergence. At the end of the simulation, you can analyse the results of the calculation using the Sire app analyse_freenrg, e.g.
+
+sire.app/bin/analyse_freenrg -i output/freenrgs.s3 -o results.txt
+
+This will calculate the potentials of mean force (PMFs) from the FEP, TI and BAR averages and will write them all to the file 'results.txt'. At the bottom of the results will be four estimates of the correction free energy. These four estimates are; estimate from analytic integration of TI, estimate from quadrature based integration of TI, estimate from FEP and estimate from BAR. The correction free energy is the average of these four estimates, while an error can be approximated by looking at the spread of these values (e.g. by a standard deviation). If the simulation is well-converged, then these four estimates should be roughly equal. Note that this correction free energy is the difference between the MM and QM models, with a fixed offset to account for the difference in ‘zero’ between the MM and QM models. To get the complete correction free energy, you must add this offset back onto the difference (the offset is printed out at the beginning of the simulation).
+
+In addition to the output/results_????.log files, Sire will also write a restart file (quantomm_restart.s3). This .s3 file contains the streamed versions of the Sire objects, and can be used to restart the simulation. Also, Sire can be instructed to write out PDB coordinate files of the intermediates in the calculation, e.g. so you can see how the molecule changes conformation as it moves from QM to MM. The PDB output files show only the atoms that move during the simulation, so do not worry if you only see a small cutout of the system.
+
+While quantomm aims to calculate the correction free energy, it is not magic, and cannot overcome errors in the parameters or model of the system. Care should be taken when interpreting the results of quantomm, and, ideally, repeat calculations should be performed, e.g. by running on snapshots taken from an equilibrated molecular dynamics simulation.
+
+If you need more help understanding or interpreting the results of a quantomm calculation then please feel free to get in touch via the Sire users mailing list.
 """
 
 from Sire.Tools import QuantumToMM
@@ -122,8 +139,9 @@ if args.author:
     must_exist = True
 
 if args.version:
-    print("\quantomm version 0.2")
-    print(Sire.Config.versionString())
+    print("quantomm -- from Sire release version <%s>" %Sire.__version__)
+    print("This particular release can be downloaded here: "
+          "https://github.com/michellab/Sire/releases/tag/v%s" %Sire.__version__)
     must_exit = True
 
 if args.help_config:

--- a/wrapper/python/scripts/somd-freenrg.py
+++ b/wrapper/python/scripts/somd-freenrg.py
@@ -63,8 +63,9 @@ if args.author:
     must_exit = True
 
 if args.version:
-    print("\somd-freenrg version 0.1")
-    print(Sire.Config.versionString())
+    print("somd-freenrg -- from Sire release version <%s>" %Sire.__version__)
+    print("This particular release can be downloaded here: "
+          "https://github.com/michellab/Sire/releases/tag/v%s" %Sire.__version__)
     must_exit = True
 
 if args.help_config:

--- a/wrapper/python/scripts/somd.py
+++ b/wrapper/python/scripts/somd.py
@@ -49,13 +49,14 @@ args = parser.parse_args()
 must_exit = False
 
 if args.author:
-    print("\nsomd was written by Gaetano Calabro, Julien Michel and Christopher Woods (C) 2014")
+    print("\nsomd was written by Gaetano Calabro, Julien Michel, Antonia Mey and Christopher Woods (C) 2015")
     print("It is based on the OpenMMMD module distributed in Sire.")
     must_exit = True
 
 if args.version:
-    print("\somd version 0.1")
-    print(Sire.Config.versionString())
+    print("somd -- from Sire release version <%s>" %Sire.__version__)
+    print("This particular release can be downloaded here: "
+          "https://github.com/michellab/Sire/releases/tag/v%s" %Sire.__version__)
     must_exit = True
 
 if args.help_config:

--- a/wrapper/python/scripts/transform.py
+++ b/wrapper/python/scripts/transform.py
@@ -5,10 +5,15 @@ Assuming you have a PDB file, “sys.pdb” that contains a molecule with residu
 
 sire.app/bin/transform -p sys.pdb -l MOL --translate 0*nanometer 3*nanometer -0.5*nanometer -o output.pdb
 
-will translate MOL by 0*nanometers along the x axis, 3 nanometers on the y axis and -0.5 nanometers on the z axis and will write the result to “output.pdb”. transform recognises all of the length units recognised by Sire (although translating by meters is perhaps a bit over the top!).
+will translate MOL by 0*nanometers along the x axis, 3 nanometers on the y axis and -0.5 nanometers on the z axis and
+will write the result to “output.pdb”. transform recognises all of the length units recognised by Sire (although
+translating by meters is perhaps a bit over the top!).
 
-You can also rotate molecules, using the “--rotate” option. By default this will use the center of mass (via the “--com” option) or center of geometry (via the “--cog” option), or you can manually specify the center using the “--rotcent” option. Rotations can be specified in degrees or radians.
-If you supply both a translation and rotation, then the rotation is performed first, and the translation is performed second.
+You can also rotate molecules, using the “--rotate” option. By default this will use the center of mass (via the
+“--com” option) or center of geometry (via the “--cog” option), or you can manually specify the center using the
+“--rotcent” option. Rotations can be specified in degrees or radians.
+If you supply both a translation and rotation, then the rotation is performed first, and the translation is performed
+second.
 
 If you need more help understanding or using align then please feel free to get in touch via the Sire users mailing list.
 """

--- a/wrapper/python/scripts/transform.py
+++ b/wrapper/python/scripts/transform.py
@@ -1,10 +1,16 @@
 description = """
 transform is a simple app that is used to perform geometric transformations on a molecule taken from a PDB file.
-Assuming you have a PDB file, “sys.pdb” that contains a molecule with residue name “MOL” then;
-sire.app/bin/transform -p sys.pdb -l MOL --translate 0*nanometer 3*nanometer -0.5*nanometer -o output.pdb
-will translate MOL by 0*nanometers along the x axis, 3 nanometers on the y axis and -0.5 nanometers on the z axis and will write the result to “output.pdb”. transform recognises all of the length units recognised by Sire (although translating by meters is perhaps a bit over the top!).
-You can also rotate molecules, using the “--rotate” option. By default this will use the center of mass (via the “--com” option) or center of geometry (via the “--cog” option), or you can manually specify the center using the “--rotcent” option. Rotations can be specified in degrees or radians.If you supply both a translation and rotation, then the rotation is performed first, and the translation is performed second.
-If you need more help understanding or using align then please feel free to get in touch via the Sire users mailing list.
+
+Assuming you have a PDB file, “sys.pdb” that contains a molecule with residue name “MOL” then;
+
+sire.app/bin/transform -p sys.pdb -l MOL --translate 0*nanometer 3*nanometer -0.5*nanometer -o output.pdb
+
+will translate MOL by 0*nanometers along the x axis, 3 nanometers on the y axis and -0.5 nanometers on the z axis and will write the result to “output.pdb”. transform recognises all of the length units recognised by Sire (although translating by meters is perhaps a bit over the top!).
+
+You can also rotate molecules, using the “--rotate” option. By default this will use the center of mass (via the “--com” option) or center of geometry (via the “--cog” option), or you can manually specify the center using the “--rotcent” option. Rotations can be specified in degrees or radians.
+If you supply both a translation and rotation, then the rotation is performed first, and the translation is performed second.
+
+If you need more help understanding or using align then please feel free to get in touch via the Sire users mailing list.
 """
 
 from Sire.IO import *
@@ -88,8 +94,9 @@ if args.author:
     must_exit = True
 
 if args.version:
-    print("\ntransform version 0.2")
-    print(Sire.Config.versionString())
+    print("transform -- from Sire release version <%s>" %Sire.__version__)
+    print("This particular release can be downloaded here: "
+          "https://github.com/michellab/Sire/releases/tag/v%s" %Sire.__version__)
     must_exit = True
 
 if must_exit:

--- a/wrapper/python/scripts/waterswap.py
+++ b/wrapper/python/scripts/waterswap.py
@@ -1,4 +1,3 @@
-
 description = """
 waterswap is a method developed and implemented using Sire that allows absolute protein-ligand binding free energies to be calculated from first-principles, condensed-phase simulations. The method is described in;
 
@@ -83,7 +82,7 @@ parser.add_argument('-c', '--coordinate_file', nargs="?",
                     help="The Amber coordinate file (with periodic box) giving the coordinates "
                          "of all of the atoms in the passed topology file.")
 
-parser.add_argument('-C', '--config', nargs="?", 
+parser.add_argument('-C', '--config', nargs="?",
                     help='Supply an optional CONFIG file to control the calculation.')
 
 parser.add_argument('--lambda_values', type=float, nargs='+',
@@ -107,9 +106,9 @@ if args.author:
     must_exit = True
 
 if args.version:
-    print("waterswap -- from Sire release version <%s>" %Sire.__version__)
+    print("waterswap -- from Sire release version <%s>" % Sire.__version__)
     print("This particular release can be downloaded here: "
-          "https://github.com/michellab/Sire/releases/tag/v%s" %Sire.__version__)
+          "https://github.com/michellab/Sire/releases/tag/v%s" % Sire.__version__)
     must_exit = True
 
 if args.help_config:
@@ -154,7 +153,7 @@ if not (os.path.exists(coord_file) and os.path.exists(top_file)):
 
     sys.exit(-1)
 
-print("\nRunning a waterswap calculation using files %s and %s." % (top_file,coord_file))
+print("\nRunning a waterswap calculation using files %s and %s." % (top_file, coord_file))
 
 ligand = None
 if args.ligand:
@@ -165,8 +164,8 @@ elif "ligand name" in params:
 
 if ligand:
     print("The absolute binding free energy of the molecule containing residue %s "
-          "will be calculated.\n" % (ligand))
-    
+          "will be calculated.\n" %ligand)
+
 else:
     print("The absolute binding free energy of the first non-protein, non-solvent "
           "molecule will be calculated.\n")
@@ -184,5 +183,5 @@ if nits:
     print("Number of iterations to perform == %d\n" % nits)
     params["nmoves"] = nits
 
-# Now lets run the WSRC calculation
+#  Now lets run the WSRC calculation
 WSRC.run(params)

--- a/wrapper/python/scripts/waterswap.py
+++ b/wrapper/python/scripts/waterswap.py
@@ -107,8 +107,9 @@ if args.author:
     must_exit = True
 
 if args.version:
-    print("\nwaterswap version 0.2")
-    print(Sire.Config.versionString())
+    print("waterswap -- from Sire release version <%s>" %Sire.__version__)
+    print("This particular release can be downloaded here: "
+          "https://github.com/michellab/Sire/releases/tag/v%s" %Sire.__version__)
     must_exit = True
 
 if args.help_config:

--- a/wrapper/python/scripts/waterview.py
+++ b/wrapper/python/scripts/waterview.py
@@ -1,9 +1,14 @@
 description = """
 waterview is a simple app that can be used to visualise how water binds to a protein. The input for the app is a snapshot from a dynamics simulation of a solvated protein-ligand complex (solvated by TIP3P in a cubic periodic box). waterview deletes the ligand from the complex, replaces it with an equal volume of water, and then runs Monte Carlo on all of the waters (the ones in the binding site and the ones swapped in in-place of the ligand). The output from the app is a series of PDB files showing the dynamics of the water, together with a grid DX file that contains the average water occupancy at each point on a 3D grid in the binding site.
-Assuming that your protein ligand complex is contained in the Amber topology and coordinate files “system.top” and “system.crd”, and the ligand contains a residue called “LIG”, then the command;
-sire.app/bin/waterview -c system.crd -t system.top -l LIG
-will run the calculation. The calculation is performed using two stages; stage 1 looks at the water molecules when the ligand is present in the binding site, while stage 2 looks at the water molecules when the ligand is substituted by water. The simulation will write the output to PDB files called “stage1_mobile_XXXX.pdb” and “stage2_mobile_XXXX.pdb” (where XXXX is an iteration number). The average grid occupancy files are “stage1_vol.dx” and “stage2_vol.dx”.waterview is a relatively quick calculation, taking minutes to hours to complete (depending on your machine and the number of iterations you want to perform). There are some more advanced options that can be set in a config file (see “--help-config”). As with the other apps, you can specify a config file using the “-C” option.
-If you need more help understanding or interpreting the results of a ligandswap calculation then please feel free to get in touch via the Sire users mailing list.
+
+Assuming that your protein ligand complex is contained in the Amber topology and coordinate files “system.top” and “system.crd”, and the ligand contains a residue called “LIG”, then the command;
+
+sire.app/bin/waterview -c system.crd -t system.top -l LIG
+
+will run the calculation. The calculation is performed using two stages; stage 1 looks at the water molecules when the ligand is present in the binding site, while stage 2 looks at the water molecules when the ligand is substituted by water. The simulation will write the output to PDB files called “stage1_mobile_XXXX.pdb” and “stage2_mobile_XXXX.pdb” (where XXXX is an iteration number). The average grid occupancy files are “stage1_vol.dx” and “stage2_vol.dx”.
+waterview is a relatively quick calculation, taking minutes to hours to complete (depending on your machine and the number of iterations you want to perform). There are some more advanced options that can be set in a config file (see “--help-config”). As with the other apps, you can specify a config file using the “-C” option.
+
+If you need more help understanding or interpreting the results of a ligandswap calculation then please feel free to get in touch via the Sire users mailing list.
 """
 
 from Sire.Tools import WaterView
@@ -67,8 +72,9 @@ if args.author:
     must_exit = True
 
 if args.version:
-    print("\nwaterview version 0.2")
-    print(Sire.Config.versionString())
+    print("waterview -- from Sire release version <%s>" %Sire.__version__)
+    print("This particular release can be downloaded here: "
+          "https://github.com/michellab/Sire/releases/tag/v%s" %Sire.__version__)
     must_exit = True
 
 if args.help_config:


### PR DESCRIPTION
This feature fixes issues #47. It is now possible to chose not save trajectories frequently at lambda values  that are 0.0<lam>1.0.
Also explicit versioning was introduced in __init__.py with an update to all command line tools in Sire using this versioning