### PR TITLE
Feature ljtail

### DIFF
--- a/wrapper/Tools/CMakeLists.txt
+++ b/wrapper/Tools/CMakeLists.txt
@@ -12,6 +12,7 @@ set ( SCRIPTS
         DCDFile.py
         FDTISingleBound.py
         FDTISingleFree.py
+        LJcutoff.py
         LSRC.py
         Nautilus.py 
         QuantumToMM.py

--- a/wrapper/Tools/CMakeLists.txt
+++ b/wrapper/Tools/CMakeLists.txt
@@ -9,6 +9,7 @@
 set ( SCRIPTS
         __init__.py
         AmberLoader.py
+        Coulcutoff.py
         DCDFile.py
         FDTISingleBound.py
         FDTISingleFree.py

--- a/wrapper/Tools/CMakeLists.txt
+++ b/wrapper/Tools/CMakeLists.txt
@@ -19,6 +19,7 @@ set ( SCRIPTS
         QuantumToMM.py
         OpenMMMD.py
         Plot.py
+        StandardState.py
         WaterChanger.py
         WaterView.py
         WSRC.py

--- a/wrapper/Tools/Coulcutoff.py
+++ b/wrapper/Tools/Coulcutoff.py
@@ -747,6 +747,6 @@ def runLambda():
         deltaG_bootstrap[x] = dG.value()
     dev_FUNC = deltaG_bootstrap.std()
     # Now compute standard deviation of the distribution of free energies
-    print ("DG_POL = %8.5f +/- %8.5f kcal/mol (1 sigma) " % (DG_POL_AVG.value(), dev_POL))
-    print ("DG_PSUM = %8.5f +/- %8.5f kcal/mol (1 sigma) " % (DG_PSUM_AVG.value(), dev_PSUM))
+    print ("DG_POL = %8.5f +/- %8.5f kcal/mol (1 sigma) " % (DG_POL_avg.value(), dev_POL))
+    print ("DG_PSUM = %8.5f +/- %8.5f kcal/mol (1 sigma) " % (DG_PSUM_avg.value(), dev_PSUM))
     print ("DG_FUNC = %8.5f +/- %8.5f kcal/mol (1 sigma) " % (DG_FUNC.value(), dev_FUNC))

--- a/wrapper/Tools/Coulcutoff.py
+++ b/wrapper/Tools/Coulcutoff.py
@@ -745,8 +745,7 @@ def runLambda():
         resampled_nrgs = resample(delta_func_nrgs)
         dG = getFreeEnergy(resampled_nrgs)
         deltaG_bootstrap[x] = dG.value()
-    devintra = deltaG_bootstrap.std()
-    dev_FUNC = math.sqrt(dev**2+devintra**2)
+    dev_FUNC = deltaG_bootstrap.std()
     # Now compute standard deviation of the distribution of free energies
     print ("DG_POL = %8.5f +/- %8.5f kcal/mol (1 sigma) " % (DG_POL_AVG.value(), dev_POL))
     print ("DG_PSUM = %8.5f +/- %8.5f kcal/mol (1 sigma) " % (DG_PSUM_AVG.value(), dev_PSUM))

--- a/wrapper/Tools/Coulcutoff.py
+++ b/wrapper/Tools/Coulcutoff.py
@@ -527,6 +527,7 @@ def SummationCorrection(solutes, solvent, space, rho_solvent_model,
 
     for molnum in molnums:
         mol = sol_mols.molecule(molnum).molecule()
+        print ("PSUM using mol %s " % mol)
         #import pdb; pdb.set_trace()
         atoms = mol.atoms()
         mol_charge = 0.0
@@ -537,7 +538,7 @@ def SummationCorrection(solutes, solvent, space, rho_solvent_model,
             charge = atom.property("charge").value()
             mass = atom.property("mass").value()
             coords = atom.property("coordinates")
-            # What about PBC ? 
+            # What about PBC ?
             mol_com[0] += coords[0]*mass
             mol_com[1] += coords[1]*mass
             mol_com[2] += coords[2]*mass
@@ -614,7 +615,7 @@ def runLambda():
     solutes = system[MGName("solutes")]
     system.setConstant(lam, lambda_val.val)
     system.add(PerturbationConstraint(solutes))
-    #system.setComponent(lam, lambda_val.val)
+    system.setComponent(lam, lambda_val.val)
     # Now loop over snapshots in dcd and accumulate energies
     start_frame = 1
     end_frame = 1000000000
@@ -627,8 +628,8 @@ def runLambda():
     mdtraj_trajfile.seek(start_frame)
     current_frame = start_frame
 
-    system = createSystemFreeEnergy(molecules)
-    
+    #system = createSystemFreeEnergy(molecules)
+
     system_solute_rf = System()
     system_solute_rf.add(solutes)
     system_solute_rf.add(system[MGName("solute_ref")])

--- a/wrapper/Tools/Coulcutoff.py
+++ b/wrapper/Tools/Coulcutoff.py
@@ -1,0 +1,489 @@
+#
+# Evaluates electrostatics corrections to free energy changes
+#
+import os,sys, random
+import math
+from Sire.Tools.OpenMMMD import *
+from Sire.Tools import Parameter, resolveParameters
+
+# Python dependencies
+#
+try:
+    import mdtraj
+except ImportError:
+    print ("LJcutoff.py depends on a working install of the python module mdtraj. Please install mdtraj in your sire python.")
+    sys.exit(-1)
+
+try:
+    import numpy as np
+except ImportError:
+    print ("LJcutoff.py depends on a working install of the python module mdtraj. Please install mdtraj in your sire python.")
+    sys.exit(-1)
+
+
+bulk_eps = Parameter("bulk_eps", 78.4,
+                     """The dielectric constant of the bulk solvent.""")
+
+bulk_rho = Parameter("bulk_rho", 1.0 * gram/(centimeter*centimeter*centimeter)\
+                     ,"""The density of buk solvent.""")
+
+trajfile = Parameter("trajfile", "traj000000001.dcd",
+                    """File name of the trajectory to process.""")
+
+stepframe = Parameter("step_frame",1,
+    """The number of frames to step to between two succcessive evaluations.""")
+
+PoissonPBCSolverBin = Parameter("PoissonPBCSolverBin","/home/julien/local/bin/pb_generalT","""Path to the PBC Poisson solver.r""")
+
+PoissonNPSolverBin = Parameter("PoissonNPSolverBin","/home/julien/local/APBS-1.4.1-binary/bin/apbs","""Path to the NP Poisson solver.""")
+
+#### Hardcoded parameters (may need revision)
+solvent_residues = ["WAT","ZBK"]
+
+def updateSystemfromTraj(system, frame_xyz, cell_lengths, cell_angles):
+    traj_coordinates = frame_xyz[0]
+
+    traj_box_x = cell_lengths[0][0].tolist()
+    traj_box_y = cell_lengths[0][1].tolist()
+    traj_box_z = cell_lengths[0][2].tolist()
+
+    traj_natoms = len(traj_coordinates)
+
+    # Sire does not support non rectangular boxes
+    newmols_coords = {}
+
+    traj_index = 0
+    mol_index = 0
+
+    molnums = system.molNums()
+    molnums.sort()
+
+    for molnum in molnums:
+        mol = system.molecule(molnum).molecule()
+        molatoms = mol.atoms()
+        molnatoms = mol.nAtoms()
+        # Create an empty coord group using molecule so we get the correct layout
+        newmol_coords = AtomCoords( mol.property("coordinates") )
+        for x in range(0,molnatoms):
+            tmparray = traj_coordinates[traj_index]
+            atom_coord = Vector( tmparray[0].tolist() , tmparray[1].tolist() , tmparray[2].tolist() )
+            atom = molatoms[x]
+            cgatomidx = atom.cgAtomIdx()
+            newmol_coords.set( cgatomidx, atom_coord)
+            traj_index += 1
+        newmols_coords[molnum] = newmol_coords
+        mol_index += 1
+
+    if traj_natoms != traj_index:
+        print ("The number of atoms in the system is not equal to the number of atoms in the trajectory file ! Aborting.")
+        sys.exit(-1)
+
+    changedmols = MoleculeGroup("changedmols")
+    mol_index = 0
+    for molnum in molnums:
+        mol = system.molecule(molnum).molecule()
+        newmol_coords = newmols_coords[molnum]
+        mol = mol.edit().setProperty("coordinates", newmol_coords).commit()
+        changedmols.add(mol)
+    system.update(changedmols)
+
+    space = PeriodicBox(Vector( traj_box_x, traj_box_y, traj_box_z ) )
+    system.setProperty("space",space)
+
+    return system
+
+def SplitSoluteSolvent(system):
+    molecules = system.molecules()
+    mol_numbers = molecules.molNums()
+    solutes = MoleculeGroup("solutes")
+    solvent = MoleculeGroup("solvent")
+    for molnum in mol_numbers:
+        mol = molecules.molecule(molnum).molecule()
+        res0 = mol.residues()[0]
+        if res0.name().value() in solvent_residues:
+            solvent.add(mol)
+        else:
+            solutes.add(mol)
+    return solutes, solvent
+
+def PoissonPBC(binary, solutes, space, cutoff, dielectric):
+
+    space_x = space.dimensions()[0]/10.0 # nm
+    space_y = space.dimensions()[1]/10.0 #
+    space_z = space.dimensions()[2]/10.0 #
+    nions = 0
+    sol_mols = solutes.molecules()
+    molnums = sol_mols.molNums()
+    for molnum in molnums:
+        mol = sol_mols.molecule(molnum).molecule()
+        nions += mol.nAtoms()
+    dielec = dielectric
+    cut = cutoff/10.0
+
+    infilepart1 = """GRID
+100 100 100
+%8.5f %8.5f %8.5f
+4
+END
+ITERATION
+200 1.5 0.3 -0.001
+0 50 50 50 1
+END
+ELECTRO
+%s %8.5f
+""" % (space_x, space_y, space_z, nions, dielec)
+
+    infilepart2 = ""
+    for molnum in molnums:
+        mol = sol_mols.molecule(molnum).molecule()
+        atoms = mol.atoms()
+        for atom in atoms:
+            charge = atom.property("charge").value()
+            sigma = atom.property("LJ").sigma().value()
+            radius = 0.5*(sigma*2**(1/6.))/10.0 # to nm. Is this a decently good approximation?
+            coords = atom.property("coordinates")/10.0 # to nm 
+            line = "%8.5f %8.5f %8.5f %8.5f %8.5f\n" % (charge, radius, coords[0], coords[1], coords[2])
+            #import pdb; pdb.set_trace()
+            infilepart2 += line
+    infilepart2 += "END\n" 
+
+    infilepart3 = """BOUNDARY
+3
+%s
+END
+""" % (cut)
+    infile = infilepart1 + infilepart2 + infilepart3
+    #lines = infile.split('\n')
+    #for line in lines:
+    #    print (line)
+    #import pdb; pdb.set_trace()
+
+    poissondir = "poisson-pbc"
+
+    cmd = " mkdir -p %s" % poissondir
+    os.system(cmd)
+
+    os.chdir(poissondir)
+
+    wstream = open('infile','w')
+    wstream.write(infile)
+    wstream.close()
+
+    cmd = "%s > PB.out" % binary
+    os.system(cmd)
+
+    cmd = "tail -1 PB.out > temp"
+    os.system(cmd)
+    rstream = open('temp','r')
+    buffer = rstream.readlines()
+    elems = buffer[0].split()
+    nrg = float(elems[1])
+
+    os.chdir("../")
+
+    cmd = "rm -rf %s" % poissondir
+    os.system(cmd)
+
+    DF_BA_PBC = nrg * kJ_per_mol
+
+    return DF_BA_PBC
+
+def PoissonNP(binary, solutes, dielectric):
+    # Here write input file for apbs...
+    DF_CB_NP = 0.0 * kcal_per_mol
+    nions = 0
+    sol_mols = solutes.molecules()
+    molnums = sol_mols.molNums()
+
+
+    xmlinpart1 = """# Only the x, y, z, charge, and radii fields are read.
+<ion-example>
+  <residue>
+     <resName>ION</resName>
+     <chainID>A</chainID>
+     <resSeq>1</resSeq>
+"""
+
+    xmlinpart2 = ""
+
+    for molnum in molnums:
+        mol = sol_mols.molecule(molnum).molecule()
+        nions += mol.nAtoms()
+        atoms = mol.atoms()
+        for atom in atoms:
+            name = atom.name().value()
+            charge = atom.property("charge").value()
+            sigma = atom.property("LJ").sigma().value()
+            radius = 0.5*(sigma*2**(1/6.)) # Ang. Is this a decently good approximation?
+            coords = atom.property("coordinates") # APBS uses angstroms
+            xmlinpart2 += "     <atom>\n"
+            xmlinpart2 += "        <serial>ATOM</serial>\n"
+            xmlinpart2 += "        <name>%s</name>\n" % name
+            xmlinpart2 += "        <x>%s</x>\n" % coords[0]
+            xmlinpart2 += "        <y>%s</y>\n" % coords[1]
+            xmlinpart2 += "        <z>%s</z>\n" % coords[2]
+            xmlinpart2 += "        <charge>%s</charge>\n" % charge
+            xmlinpart2 += "        <radius>%s</radius>\n" % radius
+            xmlinpart2 += "     </atom>\n"
+
+    xmlinpart3 = """  </residue>
+</ion-example>
+"""
+
+    xmlin = xmlinpart1 + xmlinpart2 + xmlinpart3
+
+    poissondir = "poisson-np"
+    cmd = "mkdir -p %s" % poissondir
+    os.system(cmd)
+
+    os.chdir(poissondir)
+
+    wstream = open("apbssystem.xml","w")
+    wstream.write(xmlin)
+    wstream.close()
+
+    apbsin="""#############################################################################
+### BORN ION SOLVATION ENERGY
+### $Id$
+###
+### Please see APBS documentation (http://apbs.sourceforge.net/doc/) for 
+### input file sytax.
+#############################################################################
+
+# READ IN MOLECULES
+read                                               
+    mol xml apbssystem.xml
+end
+
+# COMPUTE POTENTIAL FOR SOLVATED STATE
+elec name solvated
+    mg-auto     
+    dime 65 65 65
+    cglen 50 50 50
+    fglen 12 12 12
+    fgcent mol 1
+    cgcent mol 1
+    mol 1
+    lpbe
+    bcfl mdh
+    pdie 1.0
+    sdie %s
+    chgm spl2
+    srfm mol
+    srad 1.4
+    swin 0.3
+    sdens 10.0
+    temp 298.15
+    calcenergy total
+    calcforce no
+    write pot gz potential
+    # write pot dx potential
+    # write charge dx charge
+end
+
+# COMPUTE POTENTIAL FOR REFERENCE STATE
+elec name reference
+    mg-auto
+    dime 65 65 65
+    cglen 50 50 50
+    fglen 12 12 12
+    fgcent mol 1
+    cgcent mol 1
+    mol 1
+    lpbe
+    bcfl mdh
+    pdie 1.0
+    sdie 1.0
+    chgm spl2
+    srfm mol
+    srad 1.4
+    swin 0.3
+    sdens 10.0
+    temp 298.15
+    calcenergy total
+    calcforce no
+end
+
+# COMBINE TO GIVE SOLVATION ENERGY
+print elecEnergy solvated - reference end
+
+quit
+""" % dielectric
+
+    wstream = open("apbs.in","w")
+    wstream.write(apbsin)
+    wstream.close()
+
+    cmd = "%s apbs.in 1> apbs.out 2> apbs.err" % (binary)
+    os.system(cmd)
+
+    rstream = open("apbs.out","r")
+    buffer = rstream.readlines()
+
+    nrg = 0.0
+    nrgfound = False
+    for line in buffer:
+        if line.find("Global net ELEC" ) > 0:
+            elems = line.split()
+            #print (line)
+            #print (elems)
+            nrg = float(elems[5])
+            nrgfound = True
+            break
+    if not nrgfound:
+        print ("ERROR. Could not find electrostatic energy in apbs.out file. ABORT")
+        sys.exit(-1)
+
+    os.chdir("../")
+    cmd = "rm -rf %s" % poissondir
+    os.system(cmd)
+
+    DF_CB_NP = nrg * kJ_per_mol
+
+    return DF_CB_NP
+
+def SummationCorrection(solutes, solvent, space, rho_solvent_model,
+                        quadrupole_trace, eps_solvent_model, BAcutoff):
+    nrg = 0.0
+    sol_mols = solutes.molecules()
+    molnums = sol_mols.molNums()
+
+    for molnum in molnums:
+        mol = sol_mols.molecule(molnum).molecule()
+        #import pdb; pdb.set_trace()
+        atoms = mol.atoms()
+        mol_charge = 0.0
+        mol_com = [0.0, 0.0, 0.0]
+        mol_mass = 0.0
+        for atom in atoms:
+            name = atom.name().value()
+            charge = atom.property("charge").value()
+            mass = atom.property("mass").value()
+            coords = atom.property("coordinates")
+            # What about PBC ? 
+            mol_com[0] += coords[0]*mass
+            mol_com[1] += coords[1]*mass
+            mol_com[2] += coords[2]*mass
+            mol_charge += charge
+            mol_mass += mass
+        for x in range(0,3):
+            mol_com[x] = mol_com[x]/mol_mass
+        #print (mol_com)
+        #print (mol_charge)
+        # JM 11/15 This code only deals with the first solute molecule at present
+        break
+
+    nsolv = 0
+    solv_mols = solvent.molecules()
+    solvmolnums = solv_mols.molNums()
+    for molnum in solvmolnums:
+        solvent = solv_mols.molecule(molnum).molecule()
+        # Find com
+        solv_com = [0.0, 0.0, 0.0]
+        solv_atoms = solvent.atoms()
+        solv_mass = 0.0
+        for solv_atom in solv_atoms:
+            coords = solv_atom.property("coordinates")
+            mass = solv_atom.property("mass").value()
+            solv_mass += mass
+            for i in range(0,3):
+                solv_com[i] += coords[i]*mass
+        for i in range(0,3):
+            solv_com[i] /= solv_mass
+        #print (mol_com)
+        #print (solv_com)
+        d = space.calcDist(Vector(mol_com), Vector(solv_com))
+        #print (d)
+        if d < BAcutoff:
+            nsolv += 1
+    #print (nsolv)
+    ONE_OVER_6PI_EPS0 = 290.98622868361923
+    nrg = -ONE_OVER_6PI_EPS0 * mol_charge * quadrupole_trace *\
+        ( ( (2*(eps_solvent_model-1) / (2*eps_solvent_model+1) )*\
+              nsolv/(4*pi*(BAcutoff/10.0)**3/3.0) ) +\
+              (3/(2*eps_solvent_model)))
+    # !!! Missing (3/(2*eps_solvent_model+1)) phi_ODL term
+    #sys.exit(-1)
+    DF_PSUM = nrg * kJ_per_mol
+    return DF_PSUM
+
+@resolveParameters
+def runLambda():
+    try:
+        host = os.environ['HOSTNAME']
+    except KeyError:
+        host = "unknown"
+    print("### Running electrostatics correction calculation on %s ###" % host)
+    if verbose.val:
+        print("###================= Simulation Parameters=====================###")
+        Parameter.printAll()
+        print ("###===========================================================###\n")
+    print("lambda is %s" % lambda_val.val)
+
+    if os.path.exists(s3file.val):
+        (molecules, space) = Sire.Stream.load(s3file.val)
+    else:
+        amber = Amber()
+        (molecules, space) = amber.readCrdTop(crdfile.val, topfile.val)
+        Sire.Stream.save((molecules, space), s3file.val)
+
+    # What to do with this...
+    system = createSystemFreeEnergy(molecules)
+
+    # Now loop over snapshots in dcd and accumulate energies
+    start_frame = 1
+    end_frame = 1000000000
+    step_frame = stepframe.val
+
+    mdtraj_trajfile = mdtraj.open(trajfile.val,'r')
+    nframes = len(mdtraj_trajfile)
+    if end_frame > (nframes - 1):
+        end_frame = nframes - 1
+    mdtraj_trajfile.seek(start_frame)
+    current_frame = start_frame
+
+    while (current_frame <= end_frame):
+        frames_xyz, cell_lengths, cell_angles = mdtraj_trajfile.read(n_frames=1)
+        print ("Processing frame %s " % current_frame)
+        system = updateSystemfromTraj(system, frames_xyz, cell_lengths, cell_angles)
+        # Now filter out solvent molecules
+        solutes, solvent = SplitSoluteSolvent(system)
+        # ???Should we center solutes to the center of the box???
+        # Compute free energy corrections
+        # ############################################
+        # Use PH' solver to compute DF^{BA}_{PBC}
+        print ("Poisson PBC calculation... ")
+        DG_BA_PBC = PoissonPBC(PoissonPBCSolverBin.val ,solutes, \
+                               system.property("space"),cutoff_dist.val.value(),\
+                               bulk_eps.val)
+        # Use APBS to compute DF^{CB}_{infinity}
+        # ??? Should we use experimental dielectric constant rather than
+        # the one from the model ???
+        print ("Poisson NP calculation... ")
+        DG_CB_NP = PoissonNP(PoissonNPSolverBin.val, solutes, bulk_eps.val)
+        DG_POL = DG_CB_NP - DG_BA_PBC
+        print ("DG_POL IS %s " % DG_POL)
+        # ############################################
+        # Compute psum
+        # work out quadrupole trace of solvent model
+        # Also need to know bulk density
+        quadrupole_trace = 0.0082# e.nm^2 !!!SPC needs adjustment
+        print ("Psum correction... ")
+        DG_PSUM = SummationCorrection(solutes, solvent, space, bulk_rho.val.value(),\
+                                      quadrupole_trace, bulk_eps.val, \
+                                      cutoff_dist.val.value())
+        print ("DG_PSUM IS %s" % DG_PSUM)
+        # ############################################
+        # Compute DF_excluded (this should deal with RF in vacuum issues)
+        # Only needed for solutes with intramolecular coulombic energies
+        # ###########################################
+        # Compute DF_dir (only host/guest setups)
+        # This deals with the interaction energies of host-guest
+        # meaning will need split solutes into groups
+        # ###########################################
+        #import pdb; pdb.set_trace()
+        current_frame += step_frame
+
+    # Now compute average free energy
+    # Now compute standard deviation of the distribution of free energies
+    #print ("DeltaG = %8.5f +/- %8.5f kcal/mol (1 sigma) " % (deltaG.value(), dev))

--- a/wrapper/Tools/LJcutoff.py
+++ b/wrapper/Tools/LJcutoff.py
@@ -1,0 +1,394 @@
+#
+# Evaluates free energy difference between two potential energy functions by
+# use of the Zwanzig equation 
+#
+import os,sys
+import math
+from Sire.Tools.OpenMMMD import *
+from Sire.Tools import Parameter, resolveParameters
+
+# Python dependencies
+#
+try:
+    import mdtraj
+except ImportError:
+    print ("LJcutoff.py depends on a working install of the python module mdtraj. Please install mdtraj in your sire python.")
+    sys.exit(-1)
+
+bulk_rho = Parameter("bulk_rho", 1.0 * gram/(centimeter*centimeter*centimeter)\
+                     ,"""The density of buk solvent.""")
+trajfile = Parameter("trajfile", "traj000000001.dcd",
+                    """File name of the trajectory to process.""")
+
+
+def setupLJFF(system, space, cutoff=10* angstrom):
+
+    print ("Creating force fields... ")
+
+    solutes = system[MGName("solutes")]
+    solute = system[MGName("solute_ref")]
+    solute_hard = system[MGName("solute_ref_hard")]
+    solute_todummy = system[MGName("solute_ref_todummy")]
+    solute_fromdummy = system[MGName("solute_ref_fromdummy")]
+
+    solvent = system[MGName("solvent")]
+
+    #Solvent intramolecular CLJ energy
+    solvent_intralj = IntraCLJFF("solvent_intralj")
+    solvent_intralj.add(solvent)
+    # Solvent-solvent LJ energy
+    solventff = InterCLJFF("solvent:solvent")
+    solventff.add(solvent)
+    # Solute intramolecular LJ energy
+    solute_hard_intralj = IntraCLJFF("solute_hard_intralj")
+    solute_hard_intralj.add(solute_hard)
+
+    solute_todummy_intralj = IntraSoftCLJFF("solute_todummy_intralj")
+    solute_todummy_intralj.setShiftDelta(shift_delta.val)
+    solute_todummy_intralj.setCoulombPower(coulomb_power.val)
+    solute_todummy_intralj.add(solute_todummy)
+
+    solute_fromdummy_intralj = IntraSoftCLJFF("solute_fromdummy_intralj")
+    solute_fromdummy_intralj.setShiftDelta(shift_delta.val)
+    solute_fromdummy_intralj.setCoulombPower(coulomb_power.val)
+    solute_fromdummy_intralj.add(solute_fromdummy)
+
+    solute_hard_todummy_intralj = IntraGroupSoftCLJFF("solute_hard:todummy_intralj")
+    solute_hard_todummy_intralj.setShiftDelta(shift_delta.val)
+    solute_hard_todummy_intralj.setCoulombPower(coulomb_power.val)
+    solute_hard_todummy_intralj.add(solute_hard, MGIdx(0))
+    solute_hard_todummy_intralj.add(solute_todummy, MGIdx(1))
+
+    solute_hard_fromdummy_intralj = IntraGroupSoftCLJFF("solute_hard:fromdummy_intralj")
+    solute_hard_fromdummy_intralj.setShiftDelta(shift_delta.val)
+    solute_hard_fromdummy_intralj.setCoulombPower(coulomb_power.val)
+    solute_hard_fromdummy_intralj.add(solute_hard, MGIdx(0))
+    solute_hard_fromdummy_intralj.add(solute_fromdummy, MGIdx(1))
+
+    solute_todummy_fromdummy_intralj = IntraGroupSoftCLJFF("solute_todummy:fromdummy_intralj")
+    solute_todummy_fromdummy_intralj.setShiftDelta(shift_delta.val)
+    solute_todummy_fromdummy_intralj.setCoulombPower(coulomb_power.val)
+    solute_todummy_fromdummy_intralj.add(solute_todummy, MGIdx(0))
+    solute_todummy_fromdummy_intralj.add(solute_fromdummy, MGIdx(1))
+
+    # Solute-solvent LJ energy
+    solute_hard_solventff = InterGroupCLJFF("solute_hard:solvent")
+    solute_hard_solventff.add(solute_hard, MGIdx(0))
+    solute_hard_solventff.add(solvent, MGIdx(1))
+
+    solute_todummy_solventff = InterGroupSoftCLJFF("solute_todummy:solvent")
+    solute_todummy_solventff.add(solute_todummy, MGIdx(0))
+    solute_todummy_solventff.add(solvent, MGIdx(1))
+
+    solute_fromdummy_solventff = InterGroupSoftCLJFF("solute_fromdummy:solvent")
+    solute_fromdummy_solventff.add(solute_fromdummy, MGIdx(0))
+    solute_fromdummy_solventff.add(solvent, MGIdx(1))
+
+    # TOTAL
+    forcefields = [solute_hard_intralj, solute_todummy_intralj, solute_fromdummy_intralj,
+                   solute_hard_todummy_intralj, solute_hard_fromdummy_intralj,
+                   solute_todummy_fromdummy_intralj,
+                   solventff, solvent_intralj,
+                   solute_hard_solventff, solute_todummy_solventff, solute_fromdummy_solventff]
+
+    for forcefield in forcefields:
+        system.add(forcefield)
+
+    system.setProperty("space", space)
+    system.setProperty("switchingFunction", CHARMMSwitchingFunction(cutoff))
+    system.setProperty("combiningRules", VariantProperty(combining_rules.val))
+    system.setProperty("coulombPower", VariantProperty(coulomb_power.val))
+    system.setProperty("shiftDelta", VariantProperty(shift_delta.val))
+
+    # TOTAL
+    #total_nrg = solute_hard_intralj.components().total() + \
+    #            solute_todummy_intralj.components().total(0) + solute_fromdummy_intralj.components().total(0) + \
+    #            solute_hard_todummy_intralj.components().total(0) + solute_hard_fromdummy_intralj.components().total(0) + \
+    #            solute_todummy_fromdummy_intralj.components().total(0) + \
+    #            solventff.components().total() + \
+    #            solvent_intralj.components().total() + \
+    #            solute_hard_solventff.components().total() + \
+    #            solute_todummy_solventff.components().total(0) + \
+    #            solute_fromdummy_solventff.components().total(0)
+
+    total_nrg = solute_hard_intralj.components().lj() + \
+                solute_todummy_intralj.components().lj(0) + solute_fromdummy_intralj.components().lj(0) + \
+                solute_hard_todummy_intralj.components().lj(0) + solute_hard_fromdummy_intralj.components().lj(0) + \
+                solute_todummy_fromdummy_intralj.components().lj(0) + \
+                solventff.components().lj() + \
+                solvent_intralj.components().lj() + \
+                solute_hard_solventff.components().lj() + \
+                solute_todummy_solventff.components().lj(0) + \
+                solute_fromdummy_solventff.components().lj(0)
+
+    e_total = system.totalComponent()
+
+    lam = Symbol("lambda")
+
+    system.setComponent(e_total, total_nrg)
+
+    system.setConstant(lam, 0.0)
+
+    system.add(PerturbationConstraint(solutes))
+
+    # NON BONDED Alpha constraints for the soft force fields
+    system.add(PropertyConstraint("alpha0", FFName("solute_todummy_intralj"), lam))
+    system.add(PropertyConstraint("alpha0", FFName("solute_fromdummy_intralj"), 1 - lam))
+    system.add(PropertyConstraint("alpha0", FFName("solute_hard:todummy_intralj"), lam))
+    system.add(PropertyConstraint("alpha0", FFName("solute_hard:fromdummy_intralj"), 1 - lam))
+    system.add(PropertyConstraint("alpha0", FFName("solute_todummy:fromdummy_intralj"), Max(lam, 1 - lam)))
+    system.add(PropertyConstraint("alpha0", FFName("solute_todummy:solvent"), lam))
+    system.add(PropertyConstraint("alpha0", FFName("solute_fromdummy:solvent"), 1 - lam))
+
+    system.setComponent(lam, lambda_val.val)
+
+    return system
+
+
+def addAnalyticalLRC(system, cutoff, bulk_density):
+
+    # 1) Collect all solvent particles
+    # 2) Average all solvent sigma/epsilon parameters
+    solvent = system[MGName("solvent")]
+    solvent_mols = solvent.molecules()
+    solvent_molnums = solvent_mols.molNums()
+    #
+    # What if solvent contains more than one type of molecule?
+    #
+    #for molnum in solvent_molnums:
+    avg_sigma = 0.0 * angstrom
+    avg_epsilon = 0.0 * kcal_per_mol
+    LJsites = 0
+    # Is this always the right molecule?
+    mol = solvent_mols.first().molecule()
+    #molecule(molnum).molecule()
+    atoms = mol.atoms()
+    natoms = mol.nAtoms()
+    solv_mol_mass = 0 * g_per_mol
+    for x in range(0,natoms):
+        atom = atoms[x]
+        at_mass = atom.property("mass")
+        solv_mol_mass += at_mass
+    LJparams = mol.property("LJ").toVector()
+    for LJparam in LJparams:
+        sigma = LJparam.sigma()
+        epsilon = LJparam.epsilon()
+        print (sigma, epsilon)
+        # Are we supposed to skip null LJ sites?
+        if epsilon.value() > 0:
+            avg_epsilon += epsilon
+            avg_sigma += sigma
+            LJsites += 1
+    avg_sigma /= LJsites
+    avg_epsilon /= LJsites
+    print (avg_sigma, avg_epsilon, LJsites)
+    solv_sigma = avg_sigma
+    solv_epsilon = avg_epsilon
+    # Now for each LJsite in every molecule in the system, compute LRC term
+    molecules_group = system[MGName("molecules")]
+    # IS THE FORMULA CORRECT FOR SOFT-CORE POTENTIALS ? IN PRINCIPLE NO ERROR
+    # AT THE END STATES
+    molecules = molecules_group.molecules()
+    molnums = molecules.molNums()
+    E_lrc_full = 0.0 * kcal_per_mol
+    for molnum in molnums:
+        mol = molecules.molecule(molnum).molecule()
+        LJparams = mol.property("LJ").toVector()
+        for LJparam in LJparams:
+            sigma = LJparam.sigma()
+            epsilon = LJparam.epsilon()
+            #import pdb; pdb.set_trace()
+            eps_ij = math.sqrt(epsilon.value()*solv_epsilon.value()) \
+                     * kcal_per_mol
+            if combining_rules.val == 'arithmetic':
+                sig_ij = (0.5*(sigma+solv_sigma)).value()
+            else:
+                sig_lj = math.sqrt(sigma.value()*solv_sigma.value())
+            sig_ij6 = sig_ij**6
+            sig_ij12 = sig_ij6**2
+            sig_ij6 = sig_ij6 #* angstrom
+            sig_ij12 = sig_ij12 #* angstrom
+            # units !!
+            # density must be converted in molecule per cubic Angstrom 
+            rho = (bulk_density/solv_mol_mass).value()
+            cutval = cutoff.value()
+            #cutval = 3.15075
+            E_lrc_pairwise = 8*pi*rho*\
+                             ( (1/(9.*(cutval)**9))*(eps_ij*sig_ij12) -
+                               (1/(3.*(cutval)**3))*(eps_ij*sig_ij6) )
+            #print (E_lrc_pairwise)
+            #import pdb; pdb.set_trace()
+            #sys.exit(-1)
+            E_lrc_full += E_lrc_pairwise
+    return E_lrc_full
+
+def zeroCharges(system):
+
+    molecules = system[MGName("molecules")]
+    molnums = molecules.molNums()
+    #updated = []
+    for molnum in molnums:
+        mol = molecules.molecule(molnum).molecule()
+        editmol = mol.edit()
+        for x in range(0,mol.nAtoms()):
+            editatom = editmol.atom(AtomIdx(x))
+            editatom.setProperty("charge", 0 * mod_electron)
+            editmol = editatom.molecule()
+        mol = editmol.commit()
+        system.update(mol)
+    return system
+
+def updateSystemfromTraj(system, frame_xyz, cell_lengths, cell_angles):
+    traj_coordinates = frame_xyz[0]
+
+    traj_box_x = cell_lengths[0][0].tolist()
+    traj_box_y = cell_lengths[0][1].tolist()
+    traj_box_z = cell_lengths[0][2].tolist()
+
+    traj_natoms = len(traj_coordinates)
+
+    # Sire does not support non rectangular boxes
+    newmols_coords = {}
+
+    traj_index = 0
+    mol_index = 0
+
+    molnums = system.molNums()
+    molnums.sort()
+
+    for molnum in molnums:
+        mol = system.molecule(molnum).molecule()
+        molatoms = mol.atoms()
+        molnatoms = mol.nAtoms()
+        # Create an empty coord group using molecule so we get the correct layout
+        newmol_coords = AtomCoords( mol.property("coordinates") )
+        for x in range(0,molnatoms):
+            tmparray = traj_coordinates[traj_index]
+            atom_coord = Vector( tmparray[0].tolist() , tmparray[1].tolist() , tmparray[2].tolist() )
+            atom = molatoms[x]
+            cgatomidx = atom.cgAtomIdx()
+            newmol_coords.set( cgatomidx, atom_coord)
+            traj_index += 1
+        newmols_coords[molnum] = newmol_coords
+        mol_index += 1
+
+    if traj_natoms != traj_index:
+        print ("The number of atoms in the system is not equal to the number of atoms in the trajectory file ! Aborting.")
+        sys.exit(-1)
+
+    changedmols = MoleculeGroup("changedmols")
+    mol_index = 0
+    for molnum in molnums:
+        mol = system.molecule(molnum).molecule()
+        newmol_coords = newmols_coords[molnum]
+        mol = mol.edit().setProperty("coordinates", newmol_coords).commit()
+        changedmols.add(mol)
+    system.update(changedmols)
+
+    space = PeriodicBox(Vector( traj_box_x, traj_box_y, traj_box_z ) )
+    system.setProperty("space",space)
+
+    return system
+
+def Zwanzig(delta_nrgs):
+
+    kbt = k_boltz*temperature.val.value()
+    acc = 0.0
+    count = 0.0
+    for nrg in delta_nrgs:
+        #import pdb; pdb.set_trace()
+        acc += math.exp(-nrg.value()/kbt)
+        count += 1
+    acc /= count
+    deltaG = -kbt*math.log(acc) * kcal_per_mol
+    return deltaG
+
+@resolveParameters
+def runLambda():
+    try:
+        host = os.environ['HOSTNAME']
+    except KeyError:
+        host = "unknown"
+    print("### Running LJ tail correction calculation on %s ###" % host)
+    if verbose.val:
+        print("###================= Simulation Parameters=====================###")
+        Parameter.printAll()
+        print ("###===========================================================###\n")
+    print("lambda is %s" % lambda_val.val)
+
+    if os.path.exists(s3file.val):
+        (molecules, space) = Sire.Stream.load(s3file.val)
+    else:
+        amber = Amber()
+        (molecules, space) = amber.readCrdTop(crdfile.val, topfile.val)
+        Sire.Stream.save((molecules, space), s3file.val)
+
+    system = createSystemFreeEnergy(molecules)
+
+    # !!! NEED TO DISABLE CHANGE IN COULOMBIC CUTOFF !!
+    #system = zeroCharges(system)
+
+    #import pdb; pdb.set_trace()
+
+    # THIS IS THE ONE WITH SHORT CUTOFF
+    system_shortc = System()
+    system_shortc.copy(system)
+    #import pdb; pdb.set_trace()
+    system_shortc = setupLJFF(system_shortc, space, \
+                              cutoff=cutoff_dist.val)
+    #import pdb; pdb.set_trace()
+
+    # Determine longest cutoff that can be used. Take lowest space dimension,
+    # and decrease by 5%
+    dims = space.dimensions()
+    mindim = dims.x()
+    if mindim > dims.y():
+        mindim = dims.y()
+    if mindim > dims.z():
+        mindim = dims.z()
+    long_cutoff = (mindim/2.0 * 0.95) * angstrom
+    print (long_cutoff)
+    system_longc = System()
+    system_longc.copy(system)
+    system_longc = setupLJFF(system_longc, space, \
+                             cutoff=long_cutoff)
+    # NOW ADD ANALYTICAL CORRECTION TERM TO longc
+    E_lrc_full = addAnalyticalLRC(system_longc, long_cutoff, bulk_rho.val)
+    #import pdb; pdb.set_trace()
+    # Now loop over snapshots in dcd and accumulate energies
+    start_frame = 1
+    end_frame = 1000000000
+    step_frame = 100
+
+    #mdtraj_top = mdtraj.load_prmtop(topfile.val)
+    mdtraj_trajfile = mdtraj.open(trajfile.val,'r')
+    nframes = len(mdtraj_trajfile)
+    if end_frame > (nframes - 1):
+        end_frame = nframes - 1
+    mdtraj_trajfile.seek(start_frame)
+    current_frame = start_frame
+
+    delta_nrgs = []
+
+    while (current_frame <= end_frame):
+        frames_xyz, cell_lengths, cell_angles = mdtraj_trajfile.read(n_frames=1)
+        print ("Processing frame %s " % current_frame)
+        print (system_shortc.energy())
+        print (system_longc.energy())
+        system_shortc = updateSystemfromTraj(system_shortc, frames_xyz, cell_lengths, cell_angles)
+        system_longcc = updateSystemfromTraj(system_longc, frames_xyz, cell_lengths, cell_angles)
+        print (system_shortc.energy())
+        print (system_longc.energy())
+        delta_nrg = (system_longc.energy()+E_lrc_full - system_shortc.energy())
+        delta_nrgs.append(delta_nrg)
+
+        current_frame += step_frame
+    print (delta_nrgs)
+    # Generate X bootstrap samples
+    # Now compute free energy change and uncertainties
+    free_nrg = FreeEnergyAverage(temperature.val)
+    for nrg in delta_nrgs:
+        free_nrg.accumulate(nrg.value())
+    deltaG = free_nrg.average() * kcal_per_mol
+    print (deltaG)
+    import pdb; pdb.set_trace()

--- a/wrapper/Tools/StandardState.py
+++ b/wrapper/Tools/StandardState.py
@@ -15,14 +15,9 @@ except ImportError:
     print ("StandarState.py depends on a working install of the python module mdtraj. Please install mdtraj in your sire python.")
     sys.exit(-1)
 
-try:
-    import numpy as np
-except ImportError:
-    print ("LJcutoff.py depends on a working install of the python module mdtraj. Please install mdtraj in your sire python.")
-    sys.exit(-1)
-
 trajfile = Parameter("trajfile", "traj000000001.dcd",
                     """File name of the trajectory to process.""")
+
 stepframe = Parameter("step_frame",1,"""The number of frames to step to between two succcessive evaluations.""")
 
 @resolveParameters
@@ -37,7 +32,7 @@ def run():
         Parameter.printAll()
         print ("###===========================================================###\n")
  
-    # Check that the config files contained distance restraints, otherwise stop
+    # FIXME: Check that the config files contained distance restraints, otherwise stop
     print (distance_restraints_dict.val)
 
     #sys.exit(-1)
@@ -48,6 +43,7 @@ def run():
     step_frame = stepframe.val
 
     mdtraj_trajfile = mdtraj.open(trajfile.val,'r')
+    # FIXME: Load topology via mdtraj
     #mdtraj_topfile = Load topology file
     nframes = len(mdtraj_trajfile)
     if end_frame > (nframes - 1):
@@ -55,27 +51,28 @@ def run():
     mdtraj_trajfile.seek(start_frame)
     current_frame = start_frame
 
-    # Store coordinates of first_frame
+    # FIXME Store coordinates of first_frame
+
     restrained_atoms_coordinates = []
 
     while (current_frame <= end_frame):
         print ("Processing frame %s " % current_frame)
         frames_xyz, cell_lengths, cell_angles = mdtraj_trajfile.read(n_frames=1)
-        ## Align coordinates to first frame of the trajectory
+        ## FIXME Align coordinates to first frame of the trajectory
         #aligned_frame = alignment(frames_xyz, first_frame)
-        ## Store coordinates of atoms involved in restraints using mdtraj
+        ## FIXEME Store coordinates of atoms involved in restraints using mdtraj
         ## to select atoms by restraint indices
         #restrained_atoms_coordinates_frame = selectCoordinates(aligned_frame)
         #restrained_atoms_coordinates.append(restrained_atom_coordinates_frame)
         current_frame += step_frame
         mdtraj_trajfile.seek(current_frame)
 
-    ## Compute average coordinate of atoms involved in restraints
+    ## FIXME Compute average coordinate of atoms involved in restraints
     #averaged_restrained_atoms_coordinates = averageCoordinates(restrained_atoms_coordinates)
-    ## Define bounding cube that encompass all coordinates
+    ## FIXME Define bounding cube that encompass all coordinates
     #domain = defineIntegrationDomain(average_restrained_atoms_coordinates)
-    ## Perform integration of configuration integral
+    ## FIXME Perform integration of configuration integral
     #Ztrans = Integration(domain, distance_restraints_dict )
-    ## Convert to free energy, assuming standard state conditions
+    ## FIXME Convert to free energy, assuming standard state conditions
     #DG_restraint = restraintFreeEnergy(Ztrans)
     #print ("DG_restraint = %8.5f kcal/mol")

--- a/wrapper/Tools/StandardState.py
+++ b/wrapper/Tools/StandardState.py
@@ -8,17 +8,74 @@ from Sire.Tools.OpenMMMD import *
 from Sire.Tools import Parameter, resolveParameters
 
 # Python dependencies
-#
+
 try:
     import mdtraj
 except ImportError:
     print ("StandarState.py depends on a working install of the python module mdtraj. Please install mdtraj in your sire python.")
     sys.exit(-1)
 
+try:
+    import ast
+except ImportError:
+    print ("StandarState.py depends on a working install of the python module ast. Please install ast in your sire python.")
+    sys.exit(-1)
+
+try:
+    import shutil
+except ImportError:
+    print ("StandarState.py depends on a working install of the python module shutil. Please install shutil in your sire python.")
+    sys.exit(-1)
+
+
 trajfile = Parameter("trajfile", "traj000000001.dcd",
                     """File name of the trajectory to process.""")
 
 stepframe = Parameter("step_frame",1,"""The number of frames to step to between two succcessive evaluations.""")
+simfile  = Parameter("simfile", "sim.cfg", """ Configuration file with distance restraints dictionary""")
+topfile = Parameter("topfile", "SYSTEM.top",
+                    """File name of the topology file containing the system to be simulated.""")
+
+buff = Parameter("buff", 5.0, """Buffer to be added to coordinates to create domain of integration""")
+
+verbose = Parameter("verbose", False, """Print debug output""")
+
+
+def averageCoordinates(restr_dict):
+
+    #Calculation of the mean coordinate for every atoms
+    for idx in restr_dict.keys():
+        values = restr_dict[idx]
+        #Moltiplication by 10 since mdtraj use nm
+        x_average  = (sum(val[0] for val in values)/len(values))*10
+        y_average  = (sum(val[1] for val in values)/len(values))*10
+        z_average  = (sum(val[2] for val in values)/len(values))*10
+        #Substitution of values
+        restr_dict[idx]=(x_average,y_average,z_average)
+    return restr_dict
+
+def defineIntegrationDomain(restr_dict):
+
+    #Find the max x,y,z:
+    coord = list(restr_dict.values())
+    max_x = max(coordx[0] for coordx in coord)
+    max_y = max(coordy[1] for coordy in coord)
+    max_z = max(coordz[2] for coordz in coord)
+
+    min_x = min(coordx[0] for coordx in coord)
+    min_y = min(coordy[1] for coordy in coord)
+    min_z = min(coordz[2] for coordz in coord)
+
+    #Creation of the greatest domain plus a buffer
+    max_x += buff.val
+    max_y += buff.val
+    max_z += buff.val
+    min_x -= buff.val
+    min_y -= buff.val
+    min_z -= buff.val
+    #Adding a buffer region
+    space = [(min_x,min_y, min_z), (max_x,max_y,max_z)]
+    return space
 
 @resolveParameters
 def run():
@@ -27,52 +84,144 @@ def run():
     except KeyError:
         host = "unknown"
     print("### Running Standard state correction calculation on %s ###" % host)
+
     if verbose.val:
         print("###================= Simulation Parameters=====================###")
         Parameter.printAll()
         print ("###===========================================================###\n")
- 
-    # FIXME: Check that the config files contained distance restraints, otherwise stop
-    print (distance_restraints_dict.val)
 
-    #sys.exit(-1)
+    #Constants
+    delta = 0.10
+    delta_over_two = delta/2.0
+    deltavol = delta*delta*delta
+    kb = 0.001987
+    T = 298
+    kbT = kb*T
+    beta = 1/kbT
+    ROT = 8 * pi**2
+    Ztrans = 0.0
+    Uavg = 0
+    #Check if the configuration file contains distance restraints, otherwise stop
+    sim = open(simfile.val,"r")
+    for line in sim.readlines():
+        if "dictionary" in line:
+            restraint_dictionary = line
+            print("Found restraint dictionary %s" % restraint_dictionary)
+        else:
+            continue
+    if restraint_dictionary is None:
+        print("No restraint dictionary found in %s" % simfile.val)
+        sys.exit(-1)
 
-    # Now loop over snapshots in dcd
+    #ast automatically transform a string into a dictionary
+    rest_dict=ast.literal_eval(restraint_dictionary.strip("distance restraint dictionary="))
+    #Dictionary of restrained atoms
+    restrained_atoms={}
+    for key in rest_dict.keys():
+        for atom_idx in key:
+            if atom_idx in restrained_atoms.keys():
+                continue
+            else:
+                restrained_atoms[atom_idx] = []
+
+    #FIXME: for the moment  K,req,D must be equal for all the restrained atoms
+    req = list(rest_dict.values())[0][0]
+    K=list(rest_dict.values())[0][1]
+    D = list(rest_dict.values())[0][2]
+
+    #FIXME:supposing ligand_idx < atoms_idx, remove the ligand
+    ligand_idx = min(restrained_atoms.keys())
+    del restrained_atoms[ligand_idx]
+    print("Restrained atoms are:")
+    print(list(restrained_atoms.keys()))
+
     start_frame = 1
     end_frame = 1000000000
     step_frame = stepframe.val
-
-    mdtraj_trajfile = mdtraj.open(trajfile.val,'r')
-    # FIXME: Load topology via mdtraj
-    #mdtraj_topfile = Load topology file
+    #Check the extension of the topology file
+    #.top does not work with mdtraj
+    if ".top" in topfile.val:
+        shutil.copy(topfile.val,"SYSTEM.prmtop")
+        top_file = "SYSTEM.prmtop"
+    else:
+        top_file = topfile.val
+    print("Loading trajectory and topology files")
+    mdtraj_trajfile = mdtraj.load(trajfile.val,top=top_file)
     nframes = len(mdtraj_trajfile)
     if end_frame > (nframes - 1):
         end_frame = nframes - 1
-    mdtraj_trajfile.seek(start_frame)
+
     current_frame = start_frame
 
-    # FIXME Store coordinates of first_frame
+    #Aligning everything along the first frame
+    print("Aligning frames along first frame of trajectory")
 
-    restrained_atoms_coordinates = []
+    aligned_traj = mdtraj_trajfile.superpose(mdtraj_trajfile,0, atom_indices=list(restrained_atoms.keys()))
 
+    print("Processing frames")
     while (current_frame <= end_frame):
-        print ("Processing frame %s " % current_frame)
-        frames_xyz, cell_lengths, cell_angles = mdtraj_trajfile.read(n_frames=1)
-        ## FIXME Align coordinates to first frame of the trajectory
-        #aligned_frame = alignment(frames_xyz, first_frame)
-        ## FIXEME Store coordinates of atoms involved in restraints using mdtraj
-        ## to select atoms by restraint indices
-        #restrained_atoms_coordinates_frame = selectCoordinates(aligned_frame)
-        #restrained_atoms_coordinates.append(restrained_atom_coordinates_frame)
-        current_frame += step_frame
-        mdtraj_trajfile.seek(current_frame)
 
-    ## FIXME Compute average coordinate of atoms involved in restraints
-    #averaged_restrained_atoms_coordinates = averageCoordinates(restrained_atoms_coordinates)
-    ## FIXME Define bounding cube that encompass all coordinates
-    #domain = defineIntegrationDomain(average_restrained_atoms_coordinates)
-    ## FIXME Perform integration of configuration integral
-    #Ztrans = Integration(domain, distance_restraints_dict )
-    ## FIXME Convert to free energy, assuming standard state conditions
-    #DG_restraint = restraintFreeEnergy(Ztrans)
-    #print ("DG_restraint = %8.5f kcal/mol")
+        for idx in restrained_atoms.keys():
+
+            restrained_atoms[idx].append(aligned_traj.xyz[current_frame,idx,:].tolist())
+
+        current_frame += step_frame
+
+
+    print("Calculating average coordinates for restrained atoms")
+    restrained_atoms = averageCoordinates(restrained_atoms)
+    space = defineIntegrationDomain(restrained_atoms)
+
+    if verbose.val:
+        print("Integration space")
+        print(space)
+
+    #Grid creation
+    Nx = int ( round ( ( space[1][0] - space[0][0] ) / delta ) )
+    Ny = int ( round ( ( space[1][0] - space[0][0] ) / delta ) )
+    Nz = int ( round ( ( space[1][0] - space[0][0] ) / delta ) )
+    #Constants
+    print("Number of elements to be evaluated %d" %(Nx*Ny*Nz))
+    #Integration
+    #print(restrained_atoms)
+    upper_bound=(req+D)**2
+    lower_bound = max(req-D,0)**2
+    for i in range(0,Nx):
+        for j in range(0,Ny):
+            for k in range(0,Nz):
+                x = space[0][0] + delta*i + delta_over_two
+                y = space[0][1] + delta*j + delta_over_two
+                z = space[0][2] + delta*k + delta_over_two
+
+
+                for idx in range(0,len(restrained_atoms)):
+                    values_x = list(restrained_atoms.values())[idx][0]
+                    values_y = list(restrained_atoms.values())[idx][1]
+                    values_z = list(restrained_atoms.values())[idx][2]
+                    #is the point within the spheres of restraint?
+                    d = (x-values_x)**2 + (y-values_y)**2 + (z-values_z)**2
+                    if d <= upper_bound and d >= lower_bound:
+                        # Checked all the atoms:
+                        if idx == len(restrained_atoms) - 1:
+                            U = 0.0
+                        else:
+                            idx+=1
+                    else:
+                        d = sqrt(x**2+y**2+z**2)
+                        U = K*(d-D)**2
+                        break
+
+                Boltz = exp(-beta*U)*deltavol
+                Ztrans += (Boltz)
+                Uavg += U*Boltz*ROT
+    #Calculation of Ztot, Uavg, S, Frestraint:
+    Ztot = Ztrans*ROT
+    Uavg /= (Ztot)
+
+    Zideal = 1661.*ROT
+    Delta_F = -kbT*log(Ztot/Zideal)
+    minTDelta_S = -T*(kb*log(Ztot/Zideal)+Uavg/T)
+
+
+    print ("Ztrans  = %8.5f Angstrom^3" % Ztrans)
+    print ("Free energy Cost of removing the restraint = %8.5f kcal/mol" % -Delta_F)

--- a/wrapper/Tools/StandardState.py
+++ b/wrapper/Tools/StandardState.py
@@ -1,0 +1,81 @@
+#
+# Evaluates the free energy cost to remove a set of distance
+# restraints under standard state conditions
+
+import os,sys, random
+import math
+from Sire.Tools.OpenMMMD import *
+from Sire.Tools import Parameter, resolveParameters
+
+# Python dependencies
+#
+try:
+    import mdtraj
+except ImportError:
+    print ("StandarState.py depends on a working install of the python module mdtraj. Please install mdtraj in your sire python.")
+    sys.exit(-1)
+
+try:
+    import numpy as np
+except ImportError:
+    print ("LJcutoff.py depends on a working install of the python module mdtraj. Please install mdtraj in your sire python.")
+    sys.exit(-1)
+
+trajfile = Parameter("trajfile", "traj000000001.dcd",
+                    """File name of the trajectory to process.""")
+stepframe = Parameter("step_frame",1,"""The number of frames to step to between two succcessive evaluations.""")
+
+@resolveParameters
+def run():
+    try:
+        host = os.environ['HOSTNAME']
+    except KeyError:
+        host = "unknown"
+    print("### Running Standard state correction calculation on %s ###" % host)
+    if verbose.val:
+        print("###================= Simulation Parameters=====================###")
+        Parameter.printAll()
+        print ("###===========================================================###\n")
+ 
+    # Check that the config files contained distance restraints, otherwise stop
+    print (distance_restraints_dict.val)
+
+    #sys.exit(-1)
+
+    # Now loop over snapshots in dcd
+    start_frame = 1
+    end_frame = 1000000000
+    step_frame = stepframe.val
+
+    mdtraj_trajfile = mdtraj.open(trajfile.val,'r')
+    #mdtraj_topfile = Load topology file
+    nframes = len(mdtraj_trajfile)
+    if end_frame > (nframes - 1):
+        end_frame = nframes - 1
+    mdtraj_trajfile.seek(start_frame)
+    current_frame = start_frame
+
+    # Store coordinates of first_frame
+    restrained_atoms_coordinates = []
+
+    while (current_frame <= end_frame):
+        print ("Processing frame %s " % current_frame)
+        frames_xyz, cell_lengths, cell_angles = mdtraj_trajfile.read(n_frames=1)
+        ## Align coordinates to first frame of the trajectory
+        #aligned_frame = alignment(frames_xyz, first_frame)
+        ## Store coordinates of atoms involved in restraints using mdtraj
+        ## to select atoms by restraint indices
+        #restrained_atoms_coordinates_frame = selectCoordinates(aligned_frame)
+        #restrained_atoms_coordinates.append(restrained_atom_coordinates_frame)
+        current_frame += step_frame
+        mdtraj_trajfile.seek(current_frame)
+
+    ## Compute average coordinate of atoms involved in restraints
+    #averaged_restrained_atoms_coordinates = averageCoordinates(restrained_atoms_coordinates)
+    ## Define bounding cube that encompass all coordinates
+    #domain = defineIntegrationDomain(average_restrained_atoms_coordinates)
+    ## Perform integration of configuration integral
+    #Ztrans = Integration(domain, distance_restraints_dict )
+    ## Convert to free energy, assuming standard state conditions
+    #DG_restraint = restraintFreeEnergy(Ztrans)
+    #print ("DG_restraint = %8.5f kcal/mol")

--- a/wrapper/python/scripts/somd-coul-tailcorrection.py
+++ b/wrapper/python/scripts/somd-coul-tailcorrection.py
@@ -49,11 +49,14 @@ parser.add_argument('-m', '--morph_file', nargs="?",
 parser.add_argument('-l', '--lambda_val', nargs="?", 
                     help="The lambda value at which you want to run the simulation.")
 
-parser.add_argument('-b', '--bulk_rho', nargs="?",
-                    help="The density of the bulk solvent for LJ tail corrections.")
+parser.add_argument('-b', '--model_rho', nargs="?",
+                    help="The density of the modelled solvent for LJ tail corrections.")
 
 parser.add_argument('-e', '--bulk_eps', nargs="?",
                     help="The dielectric constant of the bulk solvent.")
+
+parser.add_argument('-d', '--model_eps', nargs="?",
+                    help="The dielectric constant of the modelled solvent.")
 
 parser.add_argument('-r', '--traj_file', nargs="?",
                     help="The trajectory file to process.")
@@ -122,13 +125,17 @@ if args.lambda_val:
     lambda_val = float(args.lambda_val)
     params["lambda_val"] = lambda_val
 
-if args.bulk_rho:
-    exec("bulk_rho = %s" % args.bulk_rho, globals())
-    params["bulk_rho"] = bulk_rho
+if args.model_rho:
+    exec("model_rho = %s" % args.model_rho, globals())
+    params["model_rho"] = model_rho
 
 if args.bulk_eps:
     exec("bulk_eps = %s" % args.bulk_eps, globals())
     params["bulk_eps"] = bulk_eps
+
+if args.model_eps:
+    exec("model_eps = %s" % args.model_eps, globals())
+    params["model_eps"] = model_eps
 
 if args.traj_file:
     traj_file = args.traj_file

--- a/wrapper/python/scripts/somd-coul-tailcorrection.py
+++ b/wrapper/python/scripts/somd-coul-tailcorrection.py
@@ -1,9 +1,10 @@
 description="""
-somd-lj-tailcorrection is a trajectory post-processing app that computes a correction 
-to computed free energy changes. This app evaluates the contributions of dispersion interactions 
-from beyond the cutoff used in the original simulation.
+somd-coul-tailcorrection is a trajectory post-processing app that computes a correction 
+to computed free energy changes. This app evaluates the free energy change to switch 
+from an atom-based barker-watts reaction field cutoff in periodic boundary conditions to 
+a coulombic description in a non periodic dielectric medium.
 """
-from Sire.Tools import LJcutoff
+from Sire.Tools import Coulcutoff
 from Sire.Tools import readParams
 from Sire.Units import *
 
@@ -13,12 +14,12 @@ import argparse
 import os
 import sys
 
-parser = argparse.ArgumentParser(description="Evaluates contribution of missing dispersion interactions"
-                                 "to a free energy change",
-                                 epilog="somd-lj-tailcorrection is built using Sire and is distributed "
-                                        "under the GPL. For more information please visit "
+parser = argparse.ArgumentParser(
+    description="Evaluates correction to free energy changes due to cutoffs truncation and finite-size effects.",
+    epilog="somd-coul-tailcorrection is built using Sire and is distributed "
+    "under the GPL. For more information please visit "
                                         "http://siremol.org",
-                                 prog="somd-lj-tailcorrection")
+                                 prog="somd-coul-tailcorrection")
 
 parser.add_argument('-C', '--config', nargs="?", 
                     help='Supply an optional CONFIG file to control the calculation.')
@@ -44,11 +45,15 @@ parser.add_argument('-c', '--coordinate_file', nargs="?",
 parser.add_argument('-m', '--morph_file', nargs="?",
                     help="The morph file describing the single topology "
                          "calculation to be performed.")
+
 parser.add_argument('-l', '--lambda_val', nargs="?", 
                     help="The lambda value at which you want to run the simulation.")
 
 parser.add_argument('-b', '--bulk_rho', nargs="?",
                     help="The density of the bulk solvent for LJ tail corrections.")
+
+parser.add_argument('-e', '--bulk_eps', nargs="?",
+                    help="The dielectric constant of the bulk solvent.")
 
 parser.add_argument('-r', '--traj_file', nargs="?",
                     help="The trajectory file to process.")
@@ -62,12 +67,12 @@ args = parser.parse_args()
 must_exit = False
 
 if args.author:
-    print("\nsomd-lj-tailcorrection was written by Julien Michel (C) 2015")
+    print("\nsomd-coul-tailcorrection was written by Julien Michel (C) 2015")
     print("It is based on the OpenMMMD module distributed in Sire.")
     must_exit = True
 
 if args.version:
-    print("somd-lj-tailcorrection -- from Sire release version <%s>" %Sire.__version__)
+    print("somd-coul-tailcorrection -- from Sire release version <%s>" %Sire.__version__)
     print("This particular release can be downloaded here: "
           "https://github.com/michellab/Sire/releases/tag/v%s" %Sire.__version__)
     must_exit = True
@@ -121,6 +126,10 @@ if args.bulk_rho:
     exec("bulk_rho = %s" % args.bulk_rho, globals())
     params["bulk_rho"] = bulk_rho
 
+if args.bulk_eps:
+    exec("bulk_eps = %s" % args.bulk_eps, globals())
+    params["bulk_eps"] = bulk_eps
+
 if args.traj_file:
     traj_file = args.traj_file
     params["trajfile"] = traj_file
@@ -148,9 +157,9 @@ if not (os.path.exists(coord_file) and os.path.exists(top_file) \
         print("(cannot find traj file %s)" % traj_file)
     sys.exit(-1)
 
-print("\nRunning a somd-lj-tailcorrection calculation using files %s, %s, %s and %s." % (top_file, coord_file, morph_file, traj_file))
+print("\nRunning a somd-coul-tailcorrection calculation using files %s, %s, %s and %s." % (top_file, coord_file, morph_file, traj_file))
 
 print (args)
 
-# Now lets run the OpenMMMD free energy calculation
-LJcutoff.runLambda(params)
+# Now lets run the calculation
+Coulcutoff.runLambda(params)

--- a/wrapper/python/scripts/somd-lj-tailcorrection.py
+++ b/wrapper/python/scripts/somd-lj-tailcorrection.py
@@ -1,0 +1,149 @@
+description="""
+somd-lj-tailcorrection is a trajectory post-processing app that computes a correction 
+to computed free energy changes. This app evaluates the contributions of dispersion interactions 
+from beyond the cutoff used in the original simulation.
+"""
+from Sire.Tools import LJcutoff
+from Sire.Tools import readParams
+from Sire.Units import *
+
+import Sire.Config
+
+import argparse
+import os
+import sys
+
+parser = argparse.ArgumentParser(description="Evaluates contribution of missing dispersion interactions"
+                                 "to a free energy change",
+                                 epilog="somd-lj-tailcorrection is built using Sire and is distributed "
+                                        "under the GPL. For more information please visit "
+                                        "http://siremol.org",
+                                 prog="somd-lj-tailcorrection")
+
+parser.add_argument('-C', '--config', nargs="?", 
+                    help='Supply an optional CONFIG file to control the calculation.')
+
+parser.add_argument('-H', '--help-config', action="store_true",
+                    help="Get additional help regarding all of the parameters "
+                         "(and their default values) that can be "
+                         "set in the optionally-supplied CONFIG file")
+
+parser.add_argument('--author', action="store_true",
+                    help="Get information about the authors of this script.")
+
+parser.add_argument('--version', action="store_true",
+                    help="Get version information about this script.")
+
+parser.add_argument('-t', '--topology_file', nargs="?",
+                    help="The Amber topology file containing the system.")
+
+parser.add_argument('-c', '--coordinate_file', nargs="?",
+                    help="The Amber coordinate file giving the coordinates "
+                         "of all of the atoms in the passed topology file.")
+
+parser.add_argument('-m', '--morph_file', nargs="?",
+                    help="The morph file describing the single topology "
+                         "calculation to be performed.")
+parser.add_argument('-l', '--lambda_val', nargs="?", 
+                    help="The lambda value at which you want to run the simulation.")
+
+parser.add_argument('-b', '--bulk_rho', nargs="?",
+                    help="The density of the bulk solvent for LJ tail corrections.")
+
+parser.add_argument('-r', '--traj_file', nargs="?",
+                    help="The trajectory file to process.")
+
+sys.stdout.write("\n")
+args = parser.parse_args()
+
+must_exit = False
+
+if args.author:
+    print("\nsomd-lj-tailcorrection was written by Julien Michel (C) 2015")
+    print("It is based on the OpenMMMD module distributed in Sire.")
+    must_exit = True
+
+if args.version:
+    print("somd-lj-tailcorrection -- from Sire release version <%s>" %Sire.__version__)
+    print("This particular release can be downloaded here: "
+          "https://github.com/michellab/Sire/releases/tag/v%s" %Sire.__version__)
+    must_exit = True
+
+if args.help_config:
+    OpenMMMD.Parameter.printAll(True)
+    must_exit = True
+
+if must_exit:
+    sys.exit(0)
+
+# If we have been given a CONFIG file, read it now
+params = {}
+
+if args.config:
+    print("Loading configuration information from file %s" % args.config)
+    params = readParams(args.config)
+
+if args.coordinate_file:
+    coord_file = args.coordinate_file
+    params["crdfile"] = coord_file
+elif "crdfile" in params:
+    coord_file = params["crdfile"]
+else:
+    coord_file = "system.crd"
+    params["crdfile"] = coord_file
+
+if args.topology_file:
+    top_file = args.topology_file
+    params["topfile"] = top_file
+elif "topfile" in params:
+    top_file = params["topfile"]
+else:
+    top_file = "system.top"
+    params["topfile"] = top_file
+
+if args.morph_file:
+    morph_file = args.morph_file
+    params["morphfile"] = morph_file
+elif "morphfile" in params:
+    morph_file = params["morphfile"]
+else:
+    morph_file = "system.morph"
+    params["morphfile"] = morph_file
+
+if args.lambda_val:
+    lambda_val = float(args.lambda_val)
+    params["lambda_val"] = lambda_val
+
+if args.bulk_rho:
+    exec("bulk_rho = %s" % args.bulk_rho, globals())
+    params["bulk_rho"] = bulk_rho
+
+if args.traj_file:
+    traj_file = args.traj_file
+    params["trajfile"] = traj_file
+elif "trajfile" in params:
+    traj_file = params["trajfile"]
+else:
+    traj_file = "traj000000001.dcd"
+    params["trajfile"] = traj_file
+
+if not (os.path.exists(coord_file) and os.path.exists(top_file) \
+        and os.path.exists(morph_file) and os.path.exists(traj_file)):
+    parser.print_help()
+    print("\nPlease supply the name of an existing topology, coordinate, morph and trajectory file.")
+    if not os.path.exists(coord_file):
+        print("(cannot find coordinate file %s)" % coord_file)
+    if not os.path.exists(top_file):
+        print("(cannot find topology file %s)" % top_file)
+    if not os.path.exists(morph_file):
+        print("(cannot find morph file %s)" % morph_file)
+    if not os.path.exists(traj_file):
+        print("(cannot find traj file %s)" % traj_file)
+    sys.exit(-1)
+
+print("\nRunning a somd-lj-tailcorrection calculation using files %s, %s, %s and %s." % (top_file, coord_file, morph_file, traj_file))
+
+print (args)
+
+# Now lets run the OpenMMMD free energy calculation
+LJcutoff.runLambda(params)

--- a/wrapper/python/scripts/somd-standardstatecorrection.py
+++ b/wrapper/python/scripts/somd-standardstatecorrection.py
@@ -1,0 +1,110 @@
+description="""
+somd-standardstatecorrection is a trajectory post-processing app that computes a the free energy 
+cost for removing a set of distance restraints."""
+
+from Sire.Tools import StandardState
+from Sire.Tools import readParams
+from Sire.Units import *
+
+import Sire.Config
+
+import argparse
+import os
+import sys
+
+parser = argparse.ArgumentParser(description="Evaluates the free energy cost for removing a restraint and setting standard state concentration",
+                                epilog="somd-standardstatecorrection is built using Sire and is distributed "
+                                        "under the GPL. For more information please visit "
+                                        "http://siremol.org",
+                                 prog="somd-standardstatecorrection")
+
+parser.add_argument('-C', '--config', nargs="?",
+                    help='Supply an optional CONFIG file to control the calculation.')
+
+parser.add_argument('-H', '--help-config', action="store_true",
+                    help="Get additional help regarding all of the parameters "
+                         "(and their default values) that can be "
+                         "set in the optionally-supplied CONFIG file")
+
+parser.add_argument('--author', action="store_true",
+                    help="Get information about the authors of this script.")
+
+parser.add_argument('--version', action="store_true",
+                    help="Get version information about this script.")
+
+parser.add_argument('-t', '--topology_file', nargs="?",
+                    help="The Amber topology file containing the system.")
+
+parser.add_argument('-r', '--traj_file', nargs="?",
+                    help="The trajectory file to process.")
+
+parser.add_argument('-s', '--step', nargs="?",
+                    help="The number of frames to skip between two snapshot evaluations.")
+
+sys.stdout.write("\n")
+args = parser.parse_args()
+
+must_exit = False
+
+if args.author:
+    print("\nsomd-standardstatecorrection was written by Julien Michel (C) 2015")
+    must_exit = True
+
+if args.version:
+    print("somd-standardstatecorrection -- from Sire release version <%s>" %Sire.__version__)
+    print("This particular release can be downloaded here: "
+          "https://github.com/michellab/Sire/releases/tag/v%s" %Sire.__version__)
+    must_exit = True
+
+if args.help_config:
+    OpenMMMD.Parameter.printAll(True)
+    must_exit = True
+
+if must_exit:
+    sys.exit(0)
+
+# If we have been given a CONFIG file, read it now
+params = {}
+
+if args.config:
+    print("Loading configuration information from file %s" % args.config)
+    params = readParams(args.config)
+
+if args.topology_file:
+    top_file = args.topology_file
+    params["topfile"] = top_file
+elif "topfile" in params:
+    top_file = params["topfile"]
+else:
+    top_file = "system.top"
+    params["topfile"] = top_file
+
+if args.traj_file:
+    traj_file = args.traj_file
+    params["trajfile"] = traj_file
+elif "trajfile" in params:
+    traj_file = params["trajfile"]
+else:
+    traj_file = "traj000000001.dcd"
+    params["trajfile"] = traj_file
+
+if args.step:
+    step_frame = int(args.step)
+    params["step_frame"] = step_frame
+
+if not (os.path.exists(top_file) \
+        and os.path.exists(traj_file)):
+    parser.print_help()
+    print("\nPlease supply the name of an existing topology and trajectory file.")
+    if not os.path.exists(top_file):
+        print("(cannot find topology file %s)" % top_file)
+    if not os.path.exists(traj_file):
+        print("(cannot find traj file %s)" % traj_file)
+    sys.exit(-1)
+
+print("\nRunning a somd-standardstatcorrection calculation using files %s and %s." % (top_file, traj_file))
+
+print (args)
+
+# Now lets run the OpenMMMD free energy calculation
+StandardState.run(params)


### PR DESCRIPTION
StandardState.py script to evaluate standard state correction

At the moment the script takes as input:  configuration file, trajectory, topology
It evaluates the standard state correction creating a domain of integration based on the coordinates of the restrained atoms plus a buffer region of 5.0 Angstrom (anyway a buffer voice  can be passed)
As output it gives the translational partition function (A**3) and the  free energy cost to remove the restraint

To be fixed:
- possibility to pass a restraint dictionary with different equilibrium length and flat bottom width for each restrained atoms: how to store different values? in restrained_atoms dictionary? in a specific list?
- get rid properly of the ligand index (at the moment I am deleting the voice from dictionary via ```del```)
