### PR TITLE
Fixed ViewsOfMol bugs in OpenMMMD.py, DCDFile.py and LJCutoff.py

### DIFF
--- a/wrapper/Tools/DCDFile.py
+++ b/wrapper/Tools/DCDFile.py
@@ -49,7 +49,7 @@ class DCDFile(object):
         molecules = group.molecules()
         molnums = molecules.molNums()
         for molnum in molnums:
-            mol = molecules.molecule(molnum).molecule()
+            mol = molecules.molecule(molnum)[0]
             nat = mol.nAtoms()
             natoms += nat
 
@@ -97,7 +97,7 @@ class DCDFile(object):
         natoms = 0
 
         for i in range(0,group.nMolecules()):
-            mol = group[MolIdx(i)].molecule()
+            mol = group[MolIdx(i)]
             nat = mol.nAtoms()
             natoms += nat
 
@@ -121,7 +121,7 @@ class DCDFile(object):
 
         for i in range(0,group.nMolecules()):
             #mol = group[MolIdx(i)].molecule()
-            mol = group[molnums[i]].molecule()
+            mol = group[molnums[i]][0]
             #print (mol)
             molcoords = mol.property("coordinates")
 
@@ -180,7 +180,7 @@ class DCDFile(object):
 
         # Find the number of buffered frames we have by inspecting the first molecule in the group
         # assuming all molecules have same number of buffered coordinates...
-        mol = group.first().molecule()
+        mol = group.first()[0]
         molprops = mol.propertyKeys()
         nbuf = 0
         for molprop in molprops:
@@ -216,7 +216,7 @@ class DCDFile(object):
             
 
             for i in range(0,group.nMolecules()):
-                mol = group[MolIdx(i)].molecule()
+                mol = group[MolIdx(i)][0]
                 nat = mol.nAtoms()
                 natoms += nat
 
@@ -233,7 +233,7 @@ class DCDFile(object):
             molnums.sort()
             for i in range(0,group.nMolecules()):
                 #mol = group[MolIdx(i)].molecule()
-                mol = group[molnums[i]].molecule()
+                mol = group[molnums[i]][0]
                 molcoords = mol.property("buffered_coord_%s" % x)
 
                 coords += molcoords.toVector()

--- a/wrapper/Tools/LJcutoff.py
+++ b/wrapper/Tools/LJcutoff.py
@@ -183,7 +183,7 @@ def addAnalyticalLRC(system, cutoff, bulk_density):
     avg_epsilon = 0.0 * kcal_per_mol
     LJsites = 0
     # Is this always the right molecule?
-    mol = solvent_mols.first().molecule()
+    mol = solvent_mols.first()[-1]
     if (mol.nAtoms() == 1):
         print ("This does not seem to be a solvent molecule. Picking up another one...")
         mol = solvent_mols.last().molecule()
@@ -221,7 +221,7 @@ def addAnalyticalLRC(system, cutoff, bulk_density):
     molnums = molecules.molNums()
     E_lrc_full = 0.0 * kcal_per_mol
     for molnum in molnums:
-        mol = molecules.molecule(molnum).molecule()
+        mol = molecules.molecule(molnum)[-1]
         LJparams = mol.property("LJ").toVector()
         for LJparam in LJparams:
             sigma = LJparam.sigma()
@@ -257,7 +257,7 @@ def zeroCharges(system):
     molnums = molecules.molNums()
     #updated = []
     for molnum in molnums:
-        mol = molecules.molecule(molnum).molecule()
+        mol = molecules.molecule(molnum)[-1] #-1 to select Molecule
         editmol = mol.edit()
         for x in range(0,mol.nAtoms()):
             editatom = editmol.atom(AtomIdx(x))
@@ -286,7 +286,7 @@ def updateSystemfromTraj(system, frame_xyz, cell_lengths, cell_angles):
     molnums.sort()
 
     for molnum in molnums:
-        mol = system.molecule(molnum).molecule()
+        mol = system.molecule(molnum)[-1]
         molatoms = mol.atoms()
         molnatoms = mol.nAtoms()
         # Create an empty coord group using molecule so we get the correct layout
@@ -308,7 +308,7 @@ def updateSystemfromTraj(system, frame_xyz, cell_lengths, cell_angles):
     changedmols = MoleculeGroup("changedmols")
     mol_index = 0
     for molnum in molnums:
-        mol = system.molecule(molnum).molecule()
+        mol = system.molecule(molnum)[-1]
         newmol_coords = newmols_coords[molnum]
         mol = mol.edit().setProperty("coordinates", newmol_coords).commit()
         changedmols.add(mol)

--- a/wrapper/Tools/OpenMMMD.py
+++ b/wrapper/Tools/OpenMMMD.py
@@ -273,7 +273,9 @@ def centerSolute(system, space):
     else:
         box_center = Vector(0.0, 0.0, 0.0)
 
-    solute = system.molecules().at(MolNum(1))  #first().molecule()
+    #select the last element of the list, in order to have a 
+    #molecule object
+    solute = system.molecules().at(MolNum(1))[-1] 
 
     solute_cog = CenterOfGeometry(solute).point()
 
@@ -282,7 +284,7 @@ def centerSolute(system, space):
     molNums = system.molNums()
 
     for molnum in molNums:
-        mol = system.molecule(molnum).molecule()
+        mol = system.molecule(molnum)[-1]
         molcoords = mol.property("coordinates")
         molcoords.translate(delta)
         mol = mol.edit().setProperty("coordinates", molcoords).commit()
@@ -299,7 +301,7 @@ def createSystem(molecules):
     moleculeList = []
 
     for moleculeNumber in moleculeNumbers:
-        molecule = molecules.molecule(moleculeNumber).molecule()
+        molecule = molecules.molecule(moleculeNumber)[-1]
         moleculeList.append(molecule)
 
     molecules = MoleculeGroup("molecules")
@@ -379,7 +381,7 @@ def setupForcefields(system, space):
         molnums = molecules.molecules().molNums()
 
         for molnum in molnums:
-            mol = molecules.molecule(molnum).molecule()
+            mol = molecules.molecule(molnum)[-1]
             try:
                 mol_restrained_atoms = propertyToAtomNumVectorList(mol.property("restrainedatoms"))
             except UserWarning as error:
@@ -572,7 +574,7 @@ def setupRestraints(system):
     molnums = molecules.molNums()
 
     for molnum in molnums:
-        mol = molecules.molecule(molnum).molecule()
+        mol = molecules.molecule(molnum)[-1]
         nats = mol.nAtoms()
         atoms = mol.atoms()
 
@@ -620,7 +622,7 @@ def setupDistanceRestraints(system, restraints=None):
         dic_items = list(restraints.items())
 
     for i in range(0, molecules.nMolecules()):
-        mol = molecules.molecule(MolNum(i + 1)).molecule()
+        mol = molecules.molecule(MolNum(i + 1))[-1]
         atoms_mol = mol.atoms()
         natoms_mol = mol.nAtoms()
         for j in range(0, natoms_mol):
@@ -642,7 +644,7 @@ def setupDistanceRestraints(system, restraints=None):
     [unique_prop_list.append(item) for item in prop_list if item not in unique_prop_list]
     print (unique_prop_list)
     #Mol number 0 will store all the information related to the bond-links in the system
-    mol0 = molecules.molecule(MolNum(1)).molecule()
+    mol0 = molecules.molecule(MolNum(1))[-1]
     mol0 = mol0.edit().setProperty("linkbonds", linkbondVectorListToProperty(unique_prop_list)).commit()
     system.update(mol0)
 
@@ -655,7 +657,7 @@ def freezeResidues(system):
     molnums = molecules.molNums()
 
     for molnum in molnums:
-        mol = molecules.molecule(molnum).molecule()
+        mol = molecules.molecule(molnum)[-1]
         nats = mol.nAtoms()
         atoms = mol.atoms()
 
@@ -683,7 +685,7 @@ increase from the heavy atom the hydrogen is bonded to.
     molnums = molecules.molNums()
 
     for molnum in molnums:
-        mol = molecules.molecule(molnum).molecule()
+        mol = molecules.molecule(molnum)[-1]
         nats = mol.nAtoms()
         atoms = mol.atoms()
 
@@ -769,7 +771,7 @@ increase from the heavy atom the hydrogen is bonded to.
                         and try again.""" % atidx)
                 sys.exit(-1)
 
-            mol = mol.edit().atom(atidx).setProperty("mass", newmass ).molecule()
+            mol = mol.edit().atom(atidx).setProperty("mass", newmass )[-1]
 
         system.update(mol)
         #import pdb; pdb.set_trace()
@@ -817,7 +819,7 @@ def createSystemFreeEnergy(molecules):
     moleculeList = []
 
     for moleculeNumber in moleculeNumbers:
-        molecule = molecules.molecule(moleculeNumber).molecule()
+        molecule = molecules.molecule(moleculeNumber)[0]
         moleculeList.append(molecule)
 
     # Scan input to find a molecule with passed residue number 
@@ -1209,7 +1211,7 @@ def clearBuffers(system):
     changedmols = MoleculeGroup("changedmols")
 
     for molnum in molnums:
-        mol = mols.molecule(molnum).molecule()
+        mol = mols.molecule(molnum)[0]
         molprops = mol.propertyKeys()
         editmol = mol.edit()
         for molprop in molprops:
@@ -1276,14 +1278,14 @@ def generateDistanceRestraintsDict(system):
     # Find atom nearest to COG
     molecules = system.molecules()
     molnums = molecules.molNums()
-    solute = molecules.at(MolNum(1)).molecule()
+    solute = molecules.at(MolNum(1))[-1]
     nearestcog_atom = getAtomNearCOG( solute )
     icoord = nearestcog_atom.property("coordinates")
     # Step 2) Find nearest 'CA' heavy atom in other solutes (skip water  & ions)
     dmin = 9999999.0
     closest = None
     for molnum in molnums:
-        molecule = molecules.molecule(molnum).molecule()
+        molecule = molecules.molecule(molnum)[-1]
         if molecule == solute:
             continue
         if molecule.residues()[0].name() == ResName("WAT"):
@@ -1302,7 +1304,7 @@ def generateDistanceRestraintsDict(system):
     dmin = 9999999.0
     mirror_closest = None
     for molnum in molnums:
-        molecule = molecules.molecule(molnum).molecule()
+        molecule = molecules.molecule(molnum)[-1]
         if molecule == solute:
             continue
         if molecule.residues()[0].name() == ResName("WAT"):


### PR DESCRIPTION
Fixed the issue #159 : 
-- modified in OpenMMMD.py  "system.molecule(molnum).molecules()" with "system.molecule(molnum)[0]"  to take 1 element from the list of ViewsOfMols. 

-- modified DCDFile.py as above to save correctly the snapshot form the system 

-- modified LJCutoff.py. In this case we need to take correctly a "Molecule" object and not a "PartialMolecule", thus the right element from the list of ViewsOfMols is always the last one, thus [-1] in the script.
