### PR TITLE
Make sure the parameter file name includes the absolute path. [ci skip]

### DIFF
--- a/corelib/src/libs/SireIO/charmmpsf.cpp
+++ b/corelib/src/libs/SireIO/charmmpsf.cpp
@@ -2851,8 +2851,11 @@ void CharmmPSF::writeToFile(const QString &filename) const
     {
         QFileInfo fi(filename);
 
-        QString param_filename = fi.completeBaseName();
-        param_filename.append(".params");
+        // Create the name of the parameter file.
+        QString param_filename = fi.absolutePath()
+                               + '/'
+                               + fi.completeBaseName()
+                               + ".params";
 
         QFile f(param_filename);
 


### PR DESCRIPTION
An accompanying CHARMM parameter file is created when writing a CharmmPSF object to file (if the Sire System from which it is generated was parametrised). The name of this parameter file should be the same as the PSF file, with the extension replaced by `.params`, i.e.:

```bash
/some/runtime/path/file.psf
/some/runtime/path/file.params
```
However, the existing code crops the absolute path from the PSF file before creating the parameter file, leaving:

```bash
/some/runtime/path/file.psf
file.params
```

It is important that the path is preserved if processes are going to be launched under a different path (such as a temporary workspace).