### PR TITLE
Fixed packaging bug with package_sire.py. Needed to explictly import …

### DIFF
--- a/wrapper/python/scripts/package_sire.py
+++ b/wrapper/python/scripts/package_sire.py
@@ -1,6 +1,8 @@
 
 from Sire.Base import *
 
+import Sire
+
 import shutil
 import sys
 import time


### PR DESCRIPTION
…the Sire

namespace

[ci skip]