### PR TITLE
Create and deploy Conda package files.

### DIFF
--- a/azure-pipelines-linux.yml
+++ b/azure-pipelines-linux.yml
@@ -31,9 +31,11 @@ jobs:
       id: $(dockerId)
     displayName: 'Deploy to siremol.org and docker'
   - script: |
-      # finally create files needed for the Sire Conda package and deploy to an object store bucket
-      # identified by 'par_url'
+      # finally create files needed for the Sire Conda package, deploy to an object store bucket
+      # identified by 'par_url', and update the Conda-Forge feedstock.
       cd docker/sire-conda-devel && docker build -f Dockerfile --build-arg par_url=$par_url . && cd -
     env:
+      github_token: $(githubToken)
+      github_email: $(githubEmail)
       par_url: $(parURL)
     displayName: 'Create Conda package files and deploy to object store'

--- a/azure-pipelines-linux.yml
+++ b/azure-pipelines-linux.yml
@@ -31,7 +31,7 @@ jobs:
       id: $(dockerId)
     displayName: 'Deploy to siremol.org and docker'
   - script: |
-      # finally create files needed for the Sire Conda package and deploy to oan object store bucket
+      # finally create files needed for the Sire Conda package and deploy to an object store bucket
       # identified by 'par_url'
       cd docker/sire-conda-devel && docker build -f Dockerfile --build-arg par_url=$par_url . && cd -
     env:

--- a/azure-pipelines-linux.yml
+++ b/azure-pipelines-linux.yml
@@ -20,7 +20,7 @@ jobs:
       cd docker/sire-package-devel && docker build -f Dockerfile -t siremol/sire-package-devel:latest . && cd -
     displayName: 'Package Sire'
   - script: |
-      # finally deploy the binary to an object store bucket identified by 'par_url'
+      # deploy the binary to an object store bucket identified by 'par_url'
       cd docker/sire-deploy-devel && docker build -f Dockerfile --build-arg par_url=$par_url . && cd -
       # now push the latest build to docker
       docker login -u $id -p $pswd
@@ -30,3 +30,10 @@ jobs:
       pswd: $(dockerPassword)
       id: $(dockerId)
     displayName: 'Deploy to siremol.org and docker'
+  - script: |
+      # finally create files needed for the Sire Conda package and deploy to oan object store bucket
+      # identified by 'par_url'
+      cd docker/sire-conda-devel && docker build -f Dockerfile --build-arg par_url=$par_url . && cd -
+    env:
+      par_url: $(parURL)
+    displayName: 'Create Conda package files and deploy to object store'

--- a/azure-pipelines-linux.yml
+++ b/azure-pipelines-linux.yml
@@ -33,7 +33,7 @@ jobs:
   - script: |
       # finally create files needed for the Sire Conda package, deploy to an object store bucket
       # identified by 'par_url', and update the Conda-Forge feedstock.
-      cd docker/sire-conda-devel && docker build -f Dockerfile --build-arg par_url=$par_url . && cd -
+      cd docker/sire-conda-devel && docker build -f Dockerfile --build-arg par_url=$par_url --build-arg github_token="$github_token" --build-arg github_email="$github_email" . && cd -
     env:
       github_token: $(githubToken)
       github_email: $(githubEmail)

--- a/azure-pipelines-linux.yml
+++ b/azure-pipelines-linux.yml
@@ -38,4 +38,4 @@ jobs:
       github_token: $(githubToken)
       github_email: $(githubEmail)
       par_url: $(parURL)
-    displayName: 'Create Conda package files and deploy to object store'
+    displayName: 'Create Conda package files, deploy to object store, and update feedstock'

--- a/azure-pipelines-osx.yml
+++ b/azure-pipelines-osx.yml
@@ -39,5 +39,5 @@ jobs:
       $HOME/sire.app/bin/conda install -y pycurl
       $HOME/sire.app/bin/python docker/sire-conda-devel/deploy.py $HOME/sire_conda_osx_latest.tar.bz2
     env:
-      par_url: $(parURL)
+      PAR_URL: $(parURL)
     displayName: 'Create Conda package files and deploy to object store'

--- a/azure-pipelines-osx.yml
+++ b/azure-pipelines-osx.yml
@@ -33,7 +33,7 @@ jobs:
       PAR_URL: $(parURL)
     displayName: 'Deploy binary to siremol.org'
   - script: |
-      # finally create files needed for the Sire Conda package and deploy to oan object store bucket
+      # finally create files needed for the Sire Conda package and deploy to an object store bucket
       # identified by 'par_url'
       $HOME/sire.app/bin/python docker/sire-conda-devel/package_conda.sh
       $HOME/sire.app/bin/conda install -y pycurl

--- a/azure-pipelines-osx.yml
+++ b/azure-pipelines-osx.yml
@@ -37,7 +37,7 @@ jobs:
       # identified by 'par_url'
       $HOME/sire.app/bin/python docker/sire-conda-devel/package_conda.sh
       $HOME/sire.app/bin/conda install -y pycurl
-      $HOME/sire.app/bin/python docker/sire-conda-devel/deploy.py $HOME/sire_conda_osx_latest.tar.bz2
+      $HOME/sire.app/bin/python docker/sire-conda-devel/deploy.py $HOME/sire_conda_latest_osx.tar.bz2
     env:
       PAR_URL: $(parURL)
     displayName: 'Create Conda package files and deploy to object store'

--- a/azure-pipelines-osx.yml
+++ b/azure-pipelines-osx.yml
@@ -26,9 +26,18 @@ jobs:
 #      $HOME/sire.app/bin/sire_test
 #    displayName: 'Run Sire tests'
   - script: |
-      # finally deploy the binary to an object store bucket identified by 'par_url'
+      # deploy the binary to an object store bucket identified by 'par_url'
       $HOME/sire.app/bin/conda install -y pycurl
       $HOME/sire.app/bin/python docker/sire-deploy-devel/deploy.py $HOME/sire_devel_latest_osx.run
     env:
       PAR_URL: $(parURL)
     displayName: 'Deploy binary to siremol.org'
+  - script: |
+      # finally create files needed for the Sire Conda package and deploy to oan object store bucket
+      # identified by 'par_url'
+      $HOME/sire.app/bin/python docker/sire-conda-devel/package_conda.sh
+      $HOME/sire.app/bin/conda install -y pycurl
+      $HOME/sire.app/bin/python docker/sire-conda-devel/deploy.py $HOME/sire_conda_osx.tar.bz2
+    env:
+      par_url: $(parURL)
+    displayName: 'Create Conda package files and deploy to object store'

--- a/azure-pipelines-osx.yml
+++ b/azure-pipelines-osx.yml
@@ -37,7 +37,7 @@ jobs:
       # identified by 'par_url'
       $HOME/sire.app/bin/python docker/sire-conda-devel/package_conda.sh
       $HOME/sire.app/bin/conda install -y pycurl
-      $HOME/sire.app/bin/python docker/sire-conda-devel/deploy.py $HOME/sire_conda_osx.tar.bz2
+      $HOME/sire.app/bin/python docker/sire-conda-devel/deploy.py $HOME/sire_conda_osx_latest.tar.bz2
     env:
       par_url: $(parURL)
     displayName: 'Create Conda package files and deploy to object store'

--- a/azure-pipelines-osx.yml
+++ b/azure-pipelines-osx.yml
@@ -35,7 +35,7 @@ jobs:
   - script: |
       # finally create files needed for the Sire Conda package and deploy to an object store bucket
       # identified by 'par_url'
-      $HOME/sire.app/bin/python docker/sire-conda-devel/package_conda.sh
+      bash docker/sire-conda-devel/package_conda.sh
       $HOME/sire.app/bin/conda install -y pycurl
       $HOME/sire.app/bin/python docker/sire-conda-devel/deploy.py $HOME/sire_conda_latest_osx.tar.bz2
     env:

--- a/azure-pipelines-osx.yml
+++ b/azure-pipelines-osx.yml
@@ -34,13 +34,10 @@ jobs:
     displayName: 'Deploy binary to siremol.org'
   - script: |
       # finally create files needed for the Sire Conda package, deploy to an object store bucket
-      # identified by 'par_url', and update the Conda-Forge feedstock.
+      # identified by 'par_url'.
       bash docker/sire-conda-devel/package_conda.sh
       $HOME/sire.app/bin/conda install -y pycurl
       $HOME/sire.app/bin/python docker/sire-conda-devel/deploy.py $HOME/sire_conda_latest_osx.tar.bz2
-      bash docker/sire-conda-devel/update_feedstock.sh
     env:
-      GITHUB_TOKEN: $(githubToken)
-      GITHUB_EMAIL: $(githubEmail)
       PAR_URL: $(parURL)
     displayName: 'Create Conda package files and deploy to object store'

--- a/azure-pipelines-osx.yml
+++ b/azure-pipelines-osx.yml
@@ -33,11 +33,14 @@ jobs:
       PAR_URL: $(parURL)
     displayName: 'Deploy binary to siremol.org'
   - script: |
-      # finally create files needed for the Sire Conda package and deploy to an object store bucket
-      # identified by 'par_url'
+      # finally create files needed for the Sire Conda package, deploy to an object store bucket
+      # identified by 'par_url', and update the Conda-Forge feedstock.
       bash docker/sire-conda-devel/package_conda.sh
       $HOME/sire.app/bin/conda install -y pycurl
       $HOME/sire.app/bin/python docker/sire-conda-devel/deploy.py $HOME/sire_conda_latest_osx.tar.bz2
+      bash docker/sire-conda-devel/update_feedstock.sh
     env:
+      GITHUB_TOKEN: $(githubToken)
+      GITHUB_EMAIL: $(githubEmail)
       PAR_URL: $(parURL)
     displayName: 'Create Conda package files and deploy to object store'

--- a/build/build_sire.py
+++ b/build/build_sire.py
@@ -253,7 +253,7 @@ if __name__ == "__main__":
                 "available - please check your openmm installation")
             sys.exit(-1)
         else:
-            print("Installing openmm from the conda-forge repository...")
+            print("Installing openmm from the Omnia channel...")
             os.system("%s install --yes -c omnia -c conda-forge openmm" % conda_exe)
             #os.system("%s install --yes openmm=7.1" % conda_exe)
             installed_something = True

--- a/build/build_sire.py
+++ b/build/build_sire.py
@@ -61,14 +61,14 @@ if __name__ == "__main__":
     install_script = sys.argv[0]
     build_dir = os.path.abspath( os.path.dirname(install_script) )
 
-    # Get the number of cores to use for any compiling - if this is 0, then 
+    # Get the number of cores to use for any compiling - if this is 0, then
     # we use all of the cores
     try:
         NCORES = int(os.environ["NCORES"])
     except KeyError:
         NCORES = args.ncores
 
-    # Get the number of cores to use for compiling the python wrappers - this 
+    # Get the number of cores to use for compiling the python wrappers - this
     # defaults to NCORES
     try:
         NPYCORES = int(os.environ["NPYCORES"])
@@ -105,7 +105,7 @@ if __name__ == "__main__":
         else:
             print("Cannot find a 'conda' binary in directory '%s'. "
                   "Are you running this script using the python executable "
-                  "from a valid miniconda or anaconda installation?" % conda_base) 
+                  "from a valid miniconda or anaconda installation?" % conda_base)
             sys.exit(-1)
         py_module_install = "\"%s\" install --yes" % conda_exe
 
@@ -235,8 +235,14 @@ if __name__ == "__main__":
     installed_something = False
 
     if len(conda_pkgs) > 0:
+        cmd = "%s config --prepend channels conda-forge" % conda_exe
+        print("Activating conda-forge channel using: '%s'" % cmd)
+        status = os.system(cmd)
+        if status != 0:
+            print("Failed to add conda-forge channel!")
+            sys.exit(-1)
         cmd = "%s %s" % (py_module_install, " ".join(conda_pkgs))
-        print("Installing packages using '%s'" % cmd)
+        print("Installing packages using: '%s'" % cmd)
         status = os.system(cmd)
         installed_something = True
         if status != 0:
@@ -254,16 +260,9 @@ if __name__ == "__main__":
             sys.exit(-1)
         else:
             print("Installing openmm from the Omnia channel...")
-            os.system("%s install --yes -c omnia -c conda-forge openmm" % conda_exe)
+            os.system("%s install --yes -c omnia openmm" % conda_exe)
             #os.system("%s install --yes openmm=7.1" % conda_exe)
             installed_something = True
-
-    if installed_something and conda_exe:
-        # need to fix numpy - breaks because of MKL blas!
-        # see https://github.com/numpy/numpy/issues/11481
-        os.system("%s uninstall --yes --force blas" % conda_exe)
-        os.system("%s install --yes \"blas=*=openblas\"" % conda_exe)
-        os.system("%s update --yes --force numpy" % conda_exe)
 
     # make sure we really have found the compilers
     if is_osx:
@@ -365,7 +364,7 @@ if __name__ == "__main__":
 
     # Now that cmake has run, we can compile and install corelib
     make_args = make_cmd(NCORES, True)
-                
+
     print("NOW RUNNING \"%s\" --build . --target %s" % (cmake, make_args))
     sys.stdout.flush()
     status = os.system("\"%s\" --build . --target %s" % (cmake, make_args))
@@ -379,7 +378,7 @@ if __name__ == "__main__":
     os.chdir(OLDPWD)
 
     wrapperdir = os.path.join(build_dir, "wrapper")
-    
+
     if not os.path.exists(wrapperdir):
         os.makedirs(wrapperdir)
 
@@ -411,7 +410,7 @@ if __name__ == "__main__":
         sys.stdout.flush()
         status = os.system(cmake_cmd)
 
-    if status != 0: 
+    if status != 0:
         print("SOMETHING WENT WRONG WHEN USING CMAKE ON WRAPPER!")
         sys.exit(-1)
 

--- a/corelib/CMakeLists.txt
+++ b/corelib/CMakeLists.txt
@@ -249,21 +249,9 @@ set (SIRE_INCLUDES "include/Sire")
 set (SIRE_CMAKEFILES "include/Sire/cmake")
 # Sire share directory (for parameters etc.)
 set (SIRE_SHARE "share/Sire")
-
-if (ANACONDA_BUILD)
-  set( SIRE_SHARE_EXPORT "pkgs/sire-${S_VERSION_MAJOR}.${S_VERSION_MINOR}.${S_VERSION_PATCH}/share/Sire" )
-else()
-  set( SIRE_SHARE_EXPORT "${SIRE_SHARE}")
-endif()
-
 # Where will the test files be saved?
 set (SIRE_TEST "test")
-
-if (ANACONDA_BUILD)
-  set( SIRE_TEST_EXPORT "pkgs/sire-${S_VERSION_MAJOR}.${S_VERSION_MINOR}.${S_VERSION_PATCH}/test" )
-else()
-  set( SIRE_SHARE_EXPORT "${SIRE_SHARE}")
-endif()
+set( SIRE_SHARE_EXPORT "${SIRE_SHARE}")
 
 # Add these directories to the RPATH variable for the libraries / executables,
 # so that they can find each other when loading

--- a/docker/sire-conda-devel/Dockerfile
+++ b/docker/sire-conda-devel/Dockerfile
@@ -23,7 +23,7 @@ RUN $HOME/sire.app/bin/conda install -y pycurl
 
 # Deploy the Conda package.
 ADD deploy.py .
-RUN $HOME/sire.app/bin/python deploy.py $HOME/sire_conda_*.tar.bz2
+RUN $HOME/sire.app/bin/python deploy.py $HOME/sire_conda_latest_linux.tar.bz2
 
 # Udpate the Conda Forge feedstock.
 ADD update_feedstock.sh .

--- a/docker/sire-conda-devel/Dockerfile
+++ b/docker/sire-conda-devel/Dockerfile
@@ -26,7 +26,7 @@ ADD deploy.py .
 RUN $HOME/sire.app/bin/python deploy.py $HOME/sire_conda_*.tar.bz2
 
 # Udpate the Conda Forge feedstock.
-ADD update_feedstock.sh
+ADD update_feedstock.sh .
 RUN $HOME/update_feedstock.sh $GITHUB_TOKEN $GITHUB_EMAIL
 
 ENTRYPOINT ["bash"]

--- a/docker/sire-conda-devel/Dockerfile
+++ b/docker/sire-conda-devel/Dockerfile
@@ -1,0 +1,26 @@
+# This image is used to build the Sire Conda package.
+
+FROM siremol/sire-devel:latest
+
+WORKDIR $HOME
+
+USER $FN_USER
+
+# Import arguments and set environment variables.
+#ARG par_url
+#ENV PAR_URL=$par_url
+
+# Add the packaging script.
+ADD package_conda.sh .
+
+# Create the compressed Conda package.
+RUN $HOME/package_conda.sh
+
+# Install pycurl
+#RUN $HOME/sire.app/bin/conda install -y pycurl
+
+# Deploy the Conda package.
+#ADD deploy.py .
+#RUN $HOME/sire.app/bin/python deploy.py $HOME/sire_conda_*.tar.bz2
+
+ENTRYPOINT ["bash"]

--- a/docker/sire-conda-devel/Dockerfile
+++ b/docker/sire-conda-devel/Dockerfile
@@ -18,8 +18,8 @@ ENV GITHUB_EMAIL=$github_email
 ADD package_conda.sh .
 RUN $HOME/package_conda.sh
 
-# Install pycurl
-RUN $HOME/sire.app/bin/conda install -y pycurl
+# Install a recent Git and PyCurl.
+RUN $HOME/sire.app/bin/conda install -y git pycurl
 
 # Deploy the Conda package.
 ADD deploy.py .

--- a/docker/sire-conda-devel/Dockerfile
+++ b/docker/sire-conda-devel/Dockerfile
@@ -8,12 +8,14 @@ USER $FN_USER
 
 # Import arguments and set environment variables.
 ARG par_url
+ARG github_token
+ARG github_email
 ENV PAR_URL=$par_url
-
-# Add the packaging script.
-ADD package_conda.sh .
+ENV GITHUB_TOKEN=$github_token
+ENV GITHUB_EMAIL=$github_email
 
 # Create the compressed Conda package.
+ADD package_conda.sh .
 RUN $HOME/package_conda.sh
 
 # Install pycurl
@@ -22,5 +24,9 @@ RUN $HOME/sire.app/bin/conda install -y pycurl
 # Deploy the Conda package.
 ADD deploy.py .
 RUN $HOME/sire.app/bin/python deploy.py $HOME/sire_conda_*.tar.bz2
+
+# Udpate the Conda Forge feedstock.
+ADD update_feedstock.sh
+RUN $HOME/update_feedstock.sh $GITHUB_TOKEN $GITHUB_EMAIL
 
 ENTRYPOINT ["bash"]

--- a/docker/sire-conda-devel/Dockerfile
+++ b/docker/sire-conda-devel/Dockerfile
@@ -18,8 +18,8 @@ ENV GITHUB_EMAIL=$github_email
 ADD package_conda.sh .
 RUN $HOME/package_conda.sh
 
-# Install a recent Git and PyCurl.
-RUN $HOME/sire.app/bin/conda install -y git pycurl
+# Install PycURL.
+RUN $HOME/sire.app/bin/conda install -y pycurl
 
 # Deploy the Conda package.
 ADD deploy.py .

--- a/docker/sire-conda-devel/Dockerfile
+++ b/docker/sire-conda-devel/Dockerfile
@@ -7,8 +7,8 @@ WORKDIR $HOME
 USER $FN_USER
 
 # Import arguments and set environment variables.
-#ARG par_url
-#ENV PAR_URL=$par_url
+ARG par_url
+ENV PAR_URL=$par_url
 
 # Add the packaging script.
 ADD package_conda.sh .
@@ -17,10 +17,10 @@ ADD package_conda.sh .
 RUN $HOME/package_conda.sh
 
 # Install pycurl
-#RUN $HOME/sire.app/bin/conda install -y pycurl
+RUN $HOME/sire.app/bin/conda install -y pycurl
 
 # Deploy the Conda package.
-#ADD deploy.py .
-#RUN $HOME/sire.app/bin/python deploy.py $HOME/sire_conda_*.tar.bz2
+ADD deploy.py .
+RUN $HOME/sire.app/bin/python deploy.py $HOME/sire_conda_*.tar.bz2
 
 ENTRYPOINT ["bash"]

--- a/docker/sire-conda-devel/deploy.py
+++ b/docker/sire-conda-devel/deploy.py
@@ -13,7 +13,7 @@ try:
     upload_file = sys.argv[1]
     key = upload_file.split("/")[-1]
 except:
-    upload_file = "/home/sireuser/sire_devel_latest_linux.run"
+    upload_file = "/home/sireuser/sire_conda_latest_linux.tar.bz2"
     key = "sire_devel_latest_linux.run"
 
 if not os.path.exists(upload_file):

--- a/docker/sire-conda-devel/deploy.py
+++ b/docker/sire-conda-devel/deploy.py
@@ -1,0 +1,38 @@
+
+import os
+import pycurl
+import sys
+from io import BytesIO
+
+par_url = os.environ["PAR_URL"]
+
+if par_url is None:
+    raise KeyError("You must supply the PAR URL!")
+
+try:
+    upload_file = sys.argv[1]
+    key = upload_file.split("/")[-1]
+except:
+    upload_file = "/home/sireuser/sire_devel_latest_linux.run"
+    key = "sire_devel_latest_linux.run"
+
+if not os.path.exists(upload_file):
+    raise ValueError("Cannot find %s" % upload_file)
+
+data = open(upload_file, "rb").read()
+
+if par_url.endswith("/"):
+    destination = "%s%s" % (par_url, key)
+else:
+    destination = "%s/%s" % (par_url, key)
+
+buffer = BytesIO()
+c = pycurl.Curl()
+c.setopt(c.URL, destination)
+c.setopt(c.WRITEDATA, buffer)
+c.setopt(c.CUSTOMREQUEST, "PUT")
+c.setopt(c.POST, True)
+c.setopt(c.POSTFIELDS, data)
+
+c.perform()
+c.close()

--- a/docker/sire-conda-devel/package_conda.sh
+++ b/docker/sire-conda-devel/package_conda.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Create the archive name.
+ARCHIVE=sire_conda_linux.tar.bz2
+if [ "$(uname)" == "Darwin" ]; then
+    ARCHIVE=sire_conda_osx.tar.bz2
+fi
+
+# Create a directory to store all of the necessary files for the Conda package.
+mkdir sire_conda
+
+# Create the required sub-directories.
+mkdir sire_conda/bin
+mkdir -p sire_conda/lib/python3.7/site-packages
+mkdir sire_conda/pkgs
+
+# Now copy the files into place.
+
+# First the binary files.
+for i in $(ls -l $HOME/sire.app/bin | grep sire_python | awk '{print $9}')
+do
+    cp $HOME/sire.app/bin/$i sire_conda/bin
+done
+
+# Next the Sire library files.
+cp $HOME/sire.app/lib/libSire* sire_conda/lib
+cp $HOME/sire.app/lib/libSquire* sire_conda/lib
+
+# Add the bundled libcpuid files.
+cp $HOME/sire.app/lib/libcpuid* sire_conda/lib
+
+# Now copy across the Sire Python package.
+cp -r $HOME/sire.app/lib/python3.7/site-packages/Sire sire_conda/lib/python3.7/site-packages
+
+# Finally the Sire pkg files.
+cp -r $HOME/sire.app/pkgs/sire* sire_conda/pkgs
+
+# Now compress the Conda package directory.
+tar -czf $ARCHIVE sire_conda
+
+# Remove the redundant package directory.
+rm -rf sire_conda

--- a/docker/sire-conda-devel/package_conda.sh
+++ b/docker/sire-conda-devel/package_conda.sh
@@ -1,42 +1,29 @@
 #!/usr/bin/env bash
 
 # Create the archive name.
-ARCHIVE=sire_conda_linux.tar.bz2
+ARCHIVE=sire_conda_linux_latest.tar.bz2
 if [ "$(uname)" == "Darwin" ]; then
-    ARCHIVE=sire_conda_osx.tar.bz2
+    ARCHIVE=sire_conda_osx_latest.tar.bz2
 fi
 
 # Create a directory to store all of the necessary files for the Conda package.
 mkdir sire_conda
 
 # Create the required sub-directories.
-mkdir sire_conda/bin
 mkdir -p sire_conda/lib/python3.7/site-packages
-mkdir sire_conda/pkgs
 
 # Now copy the files into place.
-
-# First the binary files.
-for i in $(ls -l $HOME/sire.app/bin | grep sire_python | awk '{print $9}')
-do
-    cp $HOME/sire.app/bin/$i sire_conda/bin
-done
-
-# Next the Sire library files.
-cp $HOME/sire.app/lib/libSire* sire_conda/lib
-cp $HOME/sire.app/lib/libSquire* sire_conda/lib
-
-# Add the bundled libcpuid files.
-cp $HOME/sire.app/lib/libcpuid* sire_conda/lib
+cp -r $HOME/sire.app/pkgs/sire*/bin sire_conda
+cp -r $HOME/sire.app/pkgs/sire*/include sire_conda
+cp -r $HOME/sire.app/pkgs/sire*/lib sire_conda
+cp -r $HOME/sire.app/pkgs/sire*/bundled/lib sire_conda
+cp -r $HOME/sire.app/pkgs/sire*/share sire_conda
 
 # Now copy across the Sire Python package.
 cp -r $HOME/sire.app/lib/python3.7/site-packages/Sire sire_conda/lib/python3.7/site-packages
 
-# Finally the Sire pkg files.
-cp -r $HOME/sire.app/pkgs/sire* sire_conda/pkgs
-
 # Now compress the Conda package directory.
-tar -czf $ARCHIVE sire_conda
+tar cjf $ARCHIVE sire_conda
 
 # Remove the redundant package directory.
 rm -rf sire_conda

--- a/docker/sire-conda-devel/package_conda.sh
+++ b/docker/sire-conda-devel/package_conda.sh
@@ -2,7 +2,7 @@
 
 # Create the archive name.
 ARCHIVE=sire_conda_linux_latest.tar.bz2
-if [ "$(uname)" == "Darwin" ]; then
+if [ "$(uname)" == "Darwin" ] ; then
     ARCHIVE=sire_conda_osx_latest.tar.bz2
 fi
 

--- a/docker/sire-conda-devel/package_conda.sh
+++ b/docker/sire-conda-devel/package_conda.sh
@@ -12,17 +12,17 @@ mkdir sire_conda
 # Create the required sub-directories.
 mkdir -p sire_conda/lib/python3.7/site-packages
 
-# Now copy the files into place.
+# Copy the files into place.
 cp -r $HOME/sire.app/pkgs/sire*/bin sire_conda
 cp -r $HOME/sire.app/pkgs/sire*/include sire_conda
 cp -r $HOME/sire.app/pkgs/sire*/lib sire_conda
 cp -r $HOME/sire.app/pkgs/sire*/bundled/lib sire_conda
 cp -r $HOME/sire.app/pkgs/sire*/share sire_conda
 
-# Now copy across the Sire Python package.
+# Copy across the Sire Python package.
 cp -r $HOME/sire.app/lib/python3.7/site-packages/Sire sire_conda/lib/python3.7/site-packages
 
-# Now compress the Conda package directory.
+# Compress the Conda package directory.
 tar cjf $ARCHIVE sire_conda
 
 # Remove the redundant package directory.

--- a/docker/sire-conda-devel/package_conda.sh
+++ b/docker/sire-conda-devel/package_conda.sh
@@ -2,7 +2,7 @@
 
 # Create the archive name.
 ARCHIVE=sire_conda_latest_linux.tar.bz2
-if [ "$(uname)" == "Darwin" ] ; then
+if [ "$(uname)" = "Darwin" ]; then
     ARCHIVE=sire_conda_latest_osx.tar.bz2
 fi
 

--- a/docker/sire-conda-devel/package_conda.sh
+++ b/docker/sire-conda-devel/package_conda.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 # Create the archive name.
-ARCHIVE=sire_conda_linux_latest.tar.bz2
+ARCHIVE=sire_conda_latest_linux.tar.bz2
 if [ "$(uname)" == "Darwin" ] ; then
-    ARCHIVE=sire_conda_osx_latest.tar.bz2
+    ARCHIVE=sire_conda_latest_osx.tar.bz2
 fi
 
 # Create a directory to store all of the necessary files for the Conda package.

--- a/docker/sire-conda-devel/package_conda.sh
+++ b/docker/sire-conda-devel/package_conda.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 # Create the archive name.
-ARCHIVE=sire_conda_latest_linux.tar.bz2
+ARCHIVE=$HOME/sire_conda_latest_linux.tar.bz2
 if [ "$(uname)" = "Darwin" ]; then
-    ARCHIVE=sire_conda_latest_osx.tar.bz2
+    ARCHIVE=$HOME/sire_conda_latest_osx.tar.bz2
 fi
 
 # Create a directory to store all of the necessary files for the Conda package.

--- a/docker/sire-conda-devel/update_feedstock.sh
+++ b/docker/sire-conda-devel/update_feedstock.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-# We use the Git installed within the Sire miniconda since the default on the
-# macOS build image is too old to support username:token https authentication.
+# Install Git into the Sire miniconda. The default installed on the macOS
+# build image is too old to support username:token https authentication.
+$HOME/sire.app/bin/conda install -y git
 GIT=$HOME/sire.app/bin/git
 
 # Get the GitHub token and email.

--- a/docker/sire-conda-devel/update_feedstock.sh
+++ b/docker/sire-conda-devel/update_feedstock.sh
@@ -9,7 +9,7 @@ CONDA_DIR=$HOME/staged-recipes
 
 # Delete any existing Conda Forge directory.
 if [ -d $CONDA_DIR ]; then
-    echo "Deleting existing Conda directory: '$CONDA_DIR'"
+    echo "Deleting existing Conda directory: $CONDA_DIR"
     rm -rf $CONDA_DIR
 fi
 
@@ -18,7 +18,7 @@ RECIPE=$CONDA_DIR/recipes/sire/meta.yaml
 TEMPLATE=$CONDA_DIR/recipes/sire/template.yaml
 
 # Clone the feedstock repository.
-echo "Cloning Conda Forge feedstock: 'https://github.com/michellab/staged-recipes.git'"
+echo "Cloning Conda Forge feedstock: https://github.com/michellab/staged-recipes.git"
 git clone --branch devel https://github.com/michellab/staged-recipes.git $CONDA_DIR > /dev/null 2>&1
 
 # Overwite the recipe with the template file.
@@ -35,7 +35,7 @@ echo "Downloading macOS Conda package file"
 curl --silent --insecure --location https://objectstorage.eu-frankfurt-1.oraclecloud.com/p/LSe3OL7yKxPq2d5BgBVrvWFWdFlMzBG4VKUbbMahXMU/n/chryswoods/b/sire_releases/o/sire_conda_latest_osx.tar.bz2 --output $HOME/sire_conda_latest_osx.tar.bz2
 
 # List of python dependencies.
-DEPS=(boost gsl netcdf4 openmm pyqt tbb tbb-dev)
+DEPS=(boost gsl netcdf4 openmm pyqt tbb tbb-devel)
 
 # Where the Conda environment is stored.
 CONDA_ENV=.conda_env
@@ -51,13 +51,13 @@ $HOME/sire.app/bin/conda env export -n base > $CONDA_ENV
 echo "Updating Python dependencies..."
 for dep in ${DEPS[@]}; do
     ver=$(grep "\- $dep=" $CONDA_ENV | awk -F "=" '{print $2}')
-    sed -i.bak -e "s/$dep/$dep $ver/" -- $RECIPE && rm -- $RECIPE.bak
+    sed -i "0,/$dep/s//$dep $ver/" $RECIPE
     echo "  $dep $ver"
 done
 
 # Update the Sire version number.
 echo "Updating Sire version number: '$SIRE_VER'"
-sed -i.bak -e "s/VERSION/$SIRE_VER/" -- $RECIPE && rm -- $RECIPE.bak
+sed -i "s/VERSION/$SIRE_VER/" $RECIPE
 
 # Remove the Conda environment file.
 rm -f .conda_env
@@ -68,8 +68,8 @@ CHECKSUM_OSX=$(openssl sha256 $ARCHIVE_OSX | awk '{print $2}')
 echo "Updating package checksums..."
 echo "  Linux: $CHECKSUM_LINUX"
 echo "  macOS: $CHECKSUM_OSX"
-sed -i.bak -e "s/SHA256_LINUX/$CHECKSUM_LINUX/" -- $RECIPE && rm -- $RECIPE.bak
-sed -i.bak -e "s/SHA256_OSX/$CHECKSUM_OSX/" -- $RECIPE && rm -- $RECIPE.bak
+sed -i "s/SHA256_LINUX/$CHECKSUM_LINUX/" $RECIPE
+sed -i "s/SHA256_OSX/$CHECKSUM_OSX/" $RECIPE
 
 # Remove the recipe backup file.
 rm -f $RECIPE.bak
@@ -83,5 +83,5 @@ git config user.email "$GITHUB_EMAIL" > /dev/null 2>&1
 echo "Commiting changes to feedstock"
 git commit -a -m "Updating Conda recipe." > /dev/null 2>&1
 echo "Pushing changes to remote"
-git push --repo https://biosimspacebot:$GITHUB_TOKEN@github.com/michellab/staged-recipes.git origin devel > /dev/null 2>&1
+git push --repo https://biosimspacebot:$GITHUB_TOKEN@github.com/michellab/staged-recipes.git > /dev/null 2>&1
 echo "Feedstock updated!"

--- a/docker/sire-conda-devel/update_feedstock.sh
+++ b/docker/sire-conda-devel/update_feedstock.sh
@@ -14,9 +14,15 @@ if [ -d $CONDA_DIR ]; then
     rm -rf $CONDA_DIR
 fi
 
-# Store the name of the recipe and template yaml files.
+# Store the name of the recipe and template YAML files.
 RECIPE=$CONDA_DIR/recipes/sire/meta.yaml
 TEMPLATE=$CONDA_DIR/recipes/sire/template.yaml
+
+# Clone the feedstock repository.
+git clone --branch devel https://github.com/michellab/staged-recipes.git $CONDA_DIR > /dev/null 2>&1
+
+# Overwite the recipe with the template file.
+cp $TEMPLATE $RECIPE
 
 # MacOS.
 if [ "$(uname)" = "Darwin" ]; then
@@ -39,12 +45,6 @@ elif [ "$(uname)" = "Linux" ]; then
 
     # Store the conda environment.
     $HOME/sire.app/bin/conda env export -n base > $CONDA_ENV
-
-    # Clone the feedstock repository.
-    git clone --branch devel https://github.com/michellab/staged-recipes.git $CONDA_DIR > /dev/null 2>&1
-
-    # Overwite the recipe with the template file.
-    cp $TEMPLATE $RECIPE
 
     # Loop over all dependences and replace with the version installed
     # within the Conda enviroment.

--- a/docker/sire-conda-devel/update_feedstock.sh
+++ b/docker/sire-conda-devel/update_feedstock.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 # Get the GitHub token and email.
-GITHUB_TOKEN=$1
-GITHUB_EMAIL=$2
+GITHUB_TOKEN=${GITHUB_TOKEN:-$1}
+GITHUB_EMAIL=${GITHUB_EMAIL:-$2}
 
 # Set the Conda Forge feedstock directory.
 CONDA_DIR=staged-recipes
@@ -16,37 +16,59 @@ fi
 RECIPE=$CONDA_DIR/recipes/sire/meta.yaml
 TEMPLATE=$CONDA_DIR/recipes/sire/template.yaml
 
-# List of python dependencies.
-DEPS=(boost gsl netcdf4 openmm pyqt tbb tbb-dev)
+# MacOS.
+if [ "$(uname)" = "Darwin" ]; then
+    ARCHIVE=$HOME/sire_conda_latest_osx.tar.bz2
+    SHA256=SHA256_OSX
 
-# Where the Conda environment is stored.
-CONDA_ENV=.conda_env
+# Linux.
+elif [ "$(uname)" = "Linux" ]; then
+    ARCHIVE=$HOME/sire_conda_latest_linux.tar.bz2
+    SHA256=SHA256_LINUX
 
-# Get the Sire version.
-SIRE_VER=$(git --git-dir=$HOME/Sire/.git describe --tags)
+    # List of python dependencies.
+    DEPS=(boost gsl netcdf4 openmm pyqt tbb tbb-dev)
 
-# Store the conda environment.
-$HOME/sire.app/bin/conda env export -n base > $CONDA_ENV
+    # Where the Conda environment is stored.
+    CONDA_ENV=.conda_env
 
-# Clone the feedstock repository.
-git clone --single-branch --branch devel https://github.com/michellab/staged-recipes.git > /dev/null 2>&1
+    # Get the Sire version.
+    SIRE_VER=$(git --git-dir=$HOME/Sire/.git describe --tags)
 
-# Overwite the recipe with the template file.
-cp $TEMPLATE $RECIPE
+    # Store the conda environment.
+    $HOME/sire.app/bin/conda env export -n base > $CONDA_ENV
 
-# Loop over all dependences and replace with the version installed
-# within the Conda enviroment.
-for dep in ${DEPS[@]}; do
-    ver=$(grep "\- $dep=" $CONDA_ENV | awk -F "=" '{print $2}')
-    sed -i.bak -e "s/$dep/$dep $ver/" -- $RECIPE && rm -- $RECIPE.bak
-    echo $dep $ver
-done
+    # Clone the feedstock repository.
+    git clone --single-branch --branch devel https://github.com/michellab/staged-recipes.git > /dev/null 2>&1
 
-# Update the Sire version number.
-sed -i.bak -e "s/VERSION/$SIRE_VER/" -- $RECIPE && rm -- $RECIPE.bak
+    # Overwite the recipe with the template file.
+    cp $TEMPLATE $RECIPE
 
+    # Loop over all dependences and replace with the version installed
+    # within the Conda enviroment.
+    for dep in ${DEPS[@]}; do
+        ver=$(grep "\- $dep=" $CONDA_ENV | awk -F "=" '{print $2}')
+        sed -i.bak -e "s/$dep/$dep $ver/" -- $RECIPE && rm -- $RECIPE.bak
+    done
+
+    # Update the Sire version number.
+    sed -i.bak -e "s/VERSION/$SIRE_VER/" -- $RECIPE && rm -- $RECIPE.bak
+
+    # Remove the Conda environment file.
+    rm -f .conda_env
+
+# Unsupported OS.
+else
+    echo "Unsupported operating system: '$uname'"
+    exit -1
+fi
+
+# Update the sha256 checksum.
+CHECKSUM=$(openssl sha256 $ARCHIVE | awk '{print $2}')
+sed -i.bak -e "s/$SHA256/$CHECKSUM/" -- $RECIPE && rm -- $RECIPE.bak
+
+# Remove the recipe backup file.
 rm -f $RECIPE.bak
-rm -f .conda_env
 
 # Change to Conda package directory and update git config.
 cd $CONDA_DIR

--- a/docker/sire-conda-devel/update_feedstock.sh
+++ b/docker/sire-conda-devel/update_feedstock.sh
@@ -79,4 +79,4 @@ git config user.email "$GITHUB_EMAIL"
 
 # Commit the changes to the Conda recipe.
 git commit -a -m "Updating Conda recipe."
-git push --repo https://biosimspacebot:$GITHUB_TOKEN@github.com/michellab/staged-recipes.git > /dev/null 2>&1
+git push --repo https://biosimspacebot:$GITHUB_TOKEN@github.com/michellab/staged-recipes.git origin devel

--- a/docker/sire-conda-devel/update_feedstock.sh
+++ b/docker/sire-conda-devel/update_feedstock.sh
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
 
-# Install Git into the Sire miniconda. The default installed on the macOS
-# build image is too old to support username:token https authentication.
-$HOME/sire.app/bin/conda install -y git
-GIT=$HOME/sire.app/bin/git
-
 # Get the GitHub token and email.
 GITHUB_TOKEN=${GITHUB_TOKEN:-$1}
 GITHUB_EMAIL=${GITHUB_EMAIL:-$2}
@@ -14,6 +9,7 @@ CONDA_DIR=$HOME/staged-recipes
 
 # Delete any existing Conda Forge directory.
 if [ -d $CONDA_DIR ]; then
+    echo "Deleting existing Conda directory: '$CONDA_DIR'"
     rm -rf $CONDA_DIR
 fi
 
@@ -22,67 +18,70 @@ RECIPE=$CONDA_DIR/recipes/sire/meta.yaml
 TEMPLATE=$CONDA_DIR/recipes/sire/template.yaml
 
 # Clone the feedstock repository.
-$GIT clone --branch devel https://github.com/michellab/staged-recipes.git $CONDA_DIR > /dev/null 2>&1
+echo "Cloning Conda Forge feedstock: 'https://github.com/michellab/staged-recipes.git'"
+git clone --branch devel https://github.com/michellab/staged-recipes.git $CONDA_DIR > /dev/null 2>&1
 
 # Overwite the recipe with the template file.
 cp $TEMPLATE $RECIPE
 
-# MacOS.
-if [ "$(uname)" = "Darwin" ]; then
-    ARCHIVE=$HOME/sire_conda_latest_osx.tar.bz2
-    SHA256=SHA256_OSX
+ARCHIVE_LINUX=$HOME/sire_conda_latest_linux.tar.bz2
+ARCHIVE_OSX=$HOME/sire_conda_latest_osx.tar.bz2
 
-# Linux.
-elif [ "$(uname)" = "Linux" ]; then
-    ARCHIVE=$HOME/sire_conda_latest_linux.tar.bz2
-    SHA256=SHA256_LINUX
+# Download the macOS Conda package files. The macOS Azure build is much faster
+# than the Linux one so these files should always be created by the time we
+# get to this stage. If not, then the macOS Conda package will be one commit
+# behind the Linux package.
+echo "Downloading macOS Conda package file"
+curl --silent --insecure --location https://objectstorage.eu-frankfurt-1.oraclecloud.com/p/LSe3OL7yKxPq2d5BgBVrvWFWdFlMzBG4VKUbbMahXMU/n/chryswoods/b/sire_releases/o/sire_conda_latest_osx.tar.bz2 --output $HOME/sire_conda_latest_osx.tar.bz2
 
-    # List of python dependencies.
-    DEPS=(boost gsl netcdf4 openmm pyqt tbb tbb-dev)
+# List of python dependencies.
+DEPS=(boost gsl netcdf4 openmm pyqt tbb tbb-dev)
 
-    # Where the Conda environment is stored.
-    CONDA_ENV=.conda_env
+# Where the Conda environment is stored.
+CONDA_ENV=.conda_env
 
-    # Get the Sire version.
-    SIRE_VER=$($GIT --git-dir=$HOME/Sire/.git describe --tags)
+# Get the Sire version.
+SIRE_VER=$(git --git-dir=$HOME/Sire/.git describe --tags)
 
-    # Store the conda environment.
-    $HOME/sire.app/bin/conda env export -n base > $CONDA_ENV
+# Store the conda environment.
+$HOME/sire.app/bin/conda env export -n base > $CONDA_ENV
 
-    # Loop over all dependences and replace with the version installed
-    # within the Conda enviroment.
-    for dep in ${DEPS[@]}; do
-        ver=$(grep "\- $dep=" $CONDA_ENV | awk -F "=" '{print $2}')
-        sed -i.bak -e "s/$dep/$dep $ver/" -- $RECIPE && rm -- $RECIPE.bak
-    done
+# Loop over all dependences and replace with the version installed
+# within the Conda enviroment.
+echo "Updating Python dependencies..."
+for dep in ${DEPS[@]}; do
+    ver=$(grep "\- $dep=" $CONDA_ENV | awk -F "=" '{print $2}')
+    sed -i.bak -e "s/$dep/$dep $ver/" -- $RECIPE && rm -- $RECIPE.bak
+    echo "  $dep $ver"
+done
 
-    # Update the Sire version number.
-    sed -i.bak -e "s/VERSION/$SIRE_VER/" -- $RECIPE && rm -- $RECIPE.bak
+# Update the Sire version number.
+echo "Updating Sire version number: '$SIRE_VER'"
+sed -i.bak -e "s/VERSION/$SIRE_VER/" -- $RECIPE && rm -- $RECIPE.bak
 
-    # Remove the Conda environment file.
-    rm -f .conda_env
+# Remove the Conda environment file.
+rm -f .conda_env
 
-# Unsupported OS.
-else
-    echo "Unsupported operating system: '$uname'"
-    exit -1
-fi
-
-# Update the sha256 checksum.
-CHECKSUM=$(openssl sha256 $ARCHIVE | awk '{print $2}')
-sed -i.bak -e "s/$SHA256/$CHECKSUM/" -- $RECIPE && rm -- $RECIPE.bak
+# Update the sha256 checksums.
+CHECKSUM_LINUX=$(openssl sha256 $ARCHIVE_LINUX | awk '{print $2}')
+CHECKSUM_OSX=$(openssl sha256 $ARCHIVE_OSX | awk '{print $2}')
+echo "Updating package checksums..."
+echo "  Linux: $CHECKSUM_LINUX"
+echo "  macOS: $CHECKSUM_OSX"
+sed -i.bak -e "s/SHA256_LINUX/$CHECKSUM_LINUX/" -- $RECIPE && rm -- $RECIPE.bak
+sed -i.bak -e "s/SHA256_OSX/$CHECKSUM_OSX/" -- $RECIPE && rm -- $RECIPE.bak
 
 # Remove the recipe backup file.
 rm -f $RECIPE.bak
 
 # Change to Conda package directory and update git config.
 cd $CONDA_DIR
-$GIT config user.name "BioSimSpaceBot"
-$GIT config user.email "$GITHUB_EMAIL"
+git config user.name "BioSimSpaceBot" > /dev/null 2>&1
+git config user.email "$GITHUB_EMAIL" > /dev/null 2>&1
 
-# Commit the changes to the Conda recipe. Make sure to pull and rebase before
-# pushing to avoid conflicts in the unlikely event that the Linux and macOS
-# builds make simultaneous edits.
-$GIT commit -a -m "Updating Conda recipe."
-$GIT pull --rebase origin devel
-$GIT push --repo https://biosimspacebot:$GITHUB_TOKEN@github.com/michellab/staged-recipes.git origin devel
+# Commit the changes to the Conda recipe.
+echo "Commiting changes to feedstock"
+git commit -a -m "Updating Conda recipe." > /dev/null 2>&1
+echo "Pushing changes to remote"
+git push --repo https://biosimspacebot:$GITHUB_TOKEN@github.com/michellab/staged-recipes.git origin devel > /dev/null 2>&1
+echo "Feedstock updated!"

--- a/docker/sire-conda-devel/update_feedstock.sh
+++ b/docker/sire-conda-devel/update_feedstock.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-# Switch to the home directory.
+# We use the Git installed within the Sire miniconda since the default on the
+# macOS build image is too old to support username:token https authentication.
+GIT=$HOME/sire.app/bin/git
 
 # Get the GitHub token and email.
 GITHUB_TOKEN=${GITHUB_TOKEN:-$1}
@@ -19,7 +21,7 @@ RECIPE=$CONDA_DIR/recipes/sire/meta.yaml
 TEMPLATE=$CONDA_DIR/recipes/sire/template.yaml
 
 # Clone the feedstock repository.
-git clone --branch devel https://github.com/michellab/staged-recipes.git $CONDA_DIR > /dev/null 2>&1
+$GIT clone --branch devel https://github.com/michellab/staged-recipes.git $CONDA_DIR > /dev/null 2>&1
 
 # Overwite the recipe with the template file.
 cp $TEMPLATE $RECIPE
@@ -41,7 +43,7 @@ elif [ "$(uname)" = "Linux" ]; then
     CONDA_ENV=.conda_env
 
     # Get the Sire version.
-    SIRE_VER=$(git --git-dir=$HOME/Sire/.git describe --tags)
+    SIRE_VER=$($GIT --git-dir=$HOME/Sire/.git describe --tags)
 
     # Store the conda environment.
     $HOME/sire.app/bin/conda env export -n base > $CONDA_ENV
@@ -74,12 +76,12 @@ rm -f $RECIPE.bak
 
 # Change to Conda package directory and update git config.
 cd $CONDA_DIR
-git config user.name "BioSimSpaceBot"
-git config user.email "$GITHUB_EMAIL"
+$GIT config user.name "BioSimSpaceBot"
+$GIT config user.email "$GITHUB_EMAIL"
 
 # Commit the changes to the Conda recipe. Make sure to pull and rebase before
 # pushing to avoid conflicts in the unlikely event that the Linux and macOS
 # builds make simultaneous edits.
-git commit -a -m "Updating Conda recipe."
-git pull --rebase origin devel
-git push --repo https://biosimspacebot:$GITHUB_TOKEN@github.com/michellab/staged-recipes.git origin devel
+$GIT commit -a -m "Updating Conda recipe."
+$GIT pull --rebase origin devel
+$GIT push --repo https://biosimspacebot:$GITHUB_TOKEN@github.com/michellab/staged-recipes.git origin devel

--- a/docker/sire-conda-devel/update_feedstock.sh
+++ b/docker/sire-conda-devel/update_feedstock.sh
@@ -41,7 +41,7 @@ elif [ "$(uname)" = "Linux" ]; then
     $HOME/sire.app/bin/conda env export -n base > $CONDA_ENV
 
     # Clone the feedstock repository.
-    git clone --single-branch --branch devel https://github.com/michellab/staged-recipes.git $CONDA_DIR > /dev/null 2>&1
+    git clone --branch devel https://github.com/michellab/staged-recipes.git $CONDA_DIR > /dev/null 2>&1
 
     # Overwite the recipe with the template file.
     cp $TEMPLATE $RECIPE

--- a/docker/sire-conda-devel/update_feedstock.sh
+++ b/docker/sire-conda-devel/update_feedstock.sh
@@ -77,6 +77,9 @@ cd $CONDA_DIR
 git config user.name "BioSimSpaceBot"
 git config user.email "$GITHUB_EMAIL"
 
-# Commit the changes to the Conda recipe.
+# Commit the changes to the Conda recipe. Make sure to pull and rebase before
+# pushing to avoid conflicts in the unlikely event that the Linux and macOS
+# builds make simultaneous edits.
 git commit -a -m "Updating Conda recipe."
+git pull --rebase origin devel
 git push --repo https://biosimspacebot:$GITHUB_TOKEN@github.com/michellab/staged-recipes.git origin devel

--- a/docker/sire-conda-devel/update_feedstock.sh
+++ b/docker/sire-conda-devel/update_feedstock.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 
+# Switch to the home directory.
+
 # Get the GitHub token and email.
 GITHUB_TOKEN=${GITHUB_TOKEN:-$1}
 GITHUB_EMAIL=${GITHUB_EMAIL:-$2}
 
 # Set the Conda Forge feedstock directory.
-CONDA_DIR=staged-recipes
+CONDA_DIR=$HOME/staged-recipes
 
 # Delete any existing Conda Forge directory.
 if [ -d $CONDA_DIR ]; then
@@ -39,7 +41,7 @@ elif [ "$(uname)" = "Linux" ]; then
     $HOME/sire.app/bin/conda env export -n base > $CONDA_ENV
 
     # Clone the feedstock repository.
-    git clone --single-branch --branch devel https://github.com/michellab/staged-recipes.git > /dev/null 2>&1
+    git clone --single-branch --branch devel https://github.com/michellab/staged-recipes.git $CONDA_DIR > /dev/null 2>&1
 
     # Overwite the recipe with the template file.
     cp $TEMPLATE $RECIPE

--- a/wrapper/Tools/CMakeLists.txt
+++ b/wrapper/Tools/CMakeLists.txt
@@ -15,7 +15,7 @@ set ( SCRIPTS
         FDTISingleFree.py
         LJcutoff.py
         LSRC.py
-        Nautilus.py 
+        Nautilus.py
         QuantumToMM.py
         OpenMMMD.py
         Plot.py
@@ -43,7 +43,7 @@ install( DIRECTORY ${CONFIGDIRS} DESTINATION ${SIRE_SHARE}/Tools
 
 # If this is an anaconda build, then make sure that all of the
 # necessary files are copied from the pkgs directory into the
-# anaconda lib and bin directories
+# anaconda lib, bin, and share directories
 # (do this here to make sure that it happens after installing
 #  everything else)
 if (ANACONDA_BUILD)
@@ -61,11 +61,11 @@ if (ANACONDA_BUILD)
 
   install( CODE "execute_process(COMMAND \"${ANACONDA_BASE}/bin/python\"
                       ${CMAKE_SOURCE_DIR}/build/copy_into_conda.py
-       	              ${CMAKE_INSTALL_PREFIX}/bin ${ANACONDA_BASE}/bin force
-       	                    WORKING_DIRECTORY \"${ANACONDA_BASE}\")" )
+	                  ${CMAKE_INSTALL_PREFIX}/bin ${ANACONDA_BASE}/bin force
+	                        WORKING_DIRECTORY \"${ANACONDA_BASE}\")" )
 
-  #install( CODE "execute_process(COMMAND \"${ANACONDA_BASE}/bin/python\"
-  #                    ${CMAKE_SOURCE_DIR}/build/copy_into_conda.py
-  #                    ${CMAKE_INSTALL_PREFIX}/share/Sire ${ANACONDA_BASE}/share/Sire force
-  #                          WORKING_DIRECTORY \"${ANACONDA_BASE}\")" )
+  install( CODE "execute_process(COMMAND \"${ANACONDA_BASE}/bin/python\"
+                      ${CMAKE_SOURCE_DIR}/build/copy_into_conda.py
+	                  ${CMAKE_INSTALL_PREFIX}/share ${ANACONDA_BASE}/share force
+	                        WORKING_DIRECTORY \"${ANACONDA_BASE}\")" )
 endif()

--- a/wrapper/bundled/install_boost_python.cmake
+++ b/wrapper/bundled/install_boost_python.cmake
@@ -25,7 +25,7 @@ if ( ANACONDA_BUILD )
     endif()
   else()
     find_library( BOOST_PYTHON_LIBRARY
-                  NAMES boost_python
+                  NAMES boost_python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}
                   PATHS ${SIRE_APP}/lib NO_DEFAULT_PATH )
   endif()
 elseif ( MSYS )
@@ -36,7 +36,7 @@ elseif ( MSYS )
   set ( BOOST_PYTHON_HEADERS "${Boost_INCLUDE_DIR}" )
 
 else()
-  find_library( BOOST_PYTHON_LIBRARY 
+  find_library( BOOST_PYTHON_LIBRARY
                 NAMES boost_python
                 PATHS ${BUNDLE_STAGEDIR}/lib NO_DEFAULT_PATH )
 endif()


### PR DESCRIPTION
This feature creates a minimal compressed archive containing the required iles for a Sire Conda package. The package is created as part of the Azure build pipeline for both Linux and macOS and the resulting archive is uploaded to the Oracle object store. The package files can then be downloaded in the `sire-dev` Conda recipe found [here](https://github.com/michellab/staged-recipes/tree/master/recipes/sire-dev).

Summary of changes:

1) New docker build and associated scripts added in [docker/sire-conda-devel](https://github.com/michellab/Sire/tree/feature-conda/docker/sire-conda-devel)
2) Updated [azure-pipelines-linux.yml](https://github.com/michellab/Sire/blob/feature-conda/azure-pipelines-linux.yml) and [azure-pipelines-osx.yml](https://github.com/michellab/Sire/blob/feature-conda/azure-pipelines-osx.yml) to include the new build stage.
3) We now compile in a link to a share directory within the root of the miniconda install, rather than the pkgs directory. This is done in [corelib/CMakeLists.txt](https://github.com/michellab/Sire/blob/feature-conda/corelib/CMakeLists.txt). This simplifies the packaging as we don't need to bundle files in `~/sire.app/pkgs/sire-*/share/Sire`, which are searched for when `sire_python` launches, i.e. `sire_python` now searches within `~/sire.app/share/Sire`
4) The share directory from `~/sire.app/pkgs/sire-*/share` is now copied to the miniconda root within the [wrapper/Tools/CMakeLists.txt](https://github.com/michellab/Sire/blob/feature-conda/wrapper/Tools/CMakeLists.txt) script. It looks like this used to be the case, as identical code was commented in the file already.