### PR TITLE
Fixed compiler and runtime errors

### DIFF
--- a/wrapper/CAS/_CAS_free_functions.pypp.cpp
+++ b/wrapper/CAS/_CAS_free_functions.pypp.cpp
@@ -1126,32 +1126,6 @@ void register_free_functions(){
     
     }
 
-    { //::cbrt
-    
-        typedef float ( *cbrt_function_type )( float );
-        cbrt_function_type cbrt_function_value( &::cbrt );
-        
-        bp::def( 
-            "cbrt"
-            , cbrt_function_value
-            , ( bp::arg("__lcpp_x") )
-            , "" );
-    
-    }
-
-    { //::cbrt
-    
-        typedef long double ( *cbrt_function_type )( long double );
-        cbrt_function_type cbrt_function_value( &::cbrt );
-        
-        bp::def( 
-            "cbrt"
-            , cbrt_function_value
-            , ( bp::arg("__lcpp_x") )
-            , "" );
-    
-    }
-
     { //::SireCAS::cbrt
     
         typedef ::SireCAS::Expression ( *cbrt_function_type )( ::SireCAS::Expression const & );
@@ -1174,32 +1148,6 @@ void register_free_functions(){
             "pow"
             , pow_function_value
             , ( bp::arg("arg0"), bp::arg("arg1") )
-            , "" );
-    
-    }
-
-    { //::pow
-    
-        typedef float ( *pow_function_type )( float,float );
-        pow_function_type pow_function_value( &::pow );
-        
-        bp::def( 
-            "pow"
-            , pow_function_value
-            , ( bp::arg("__lcpp_x"), bp::arg("__lcpp_y") )
-            , "" );
-    
-    }
-
-    { //::pow
-    
-        typedef long double ( *pow_function_type )( long double,long double );
-        pow_function_type pow_function_value( &::pow );
-        
-        bp::def( 
-            "pow"
-            , pow_function_value
-            , ( bp::arg("__lcpp_x"), bp::arg("__lcpp_y") )
             , "" );
     
     }
@@ -1360,31 +1308,6 @@ void register_free_functions(){
     
     }
 
-    { //::sqrt
-    
-        typedef float ( *sqrt_function_type )( float );
-        sqrt_function_type sqrt_function_value( &::sqrt );
-        
-        bp::def( 
-            "sqrt"
-            , sqrt_function_value
-            , ( bp::arg("__lcpp_x") )
-            , "" );
-    
-    }
-
-    { //::sqrt
-    
-        typedef long double ( *sqrt_function_type )( long double );
-        sqrt_function_type sqrt_function_value( &::sqrt );
-        
-        bp::def( 
-            "sqrt"
-            , sqrt_function_value
-            , ( bp::arg("__lcpp_x") )
-            , "" );
-    
-    }
 
     { //::SireCAS::sqrt
     

--- a/wrapper/FF/ForceFields.pypp.cpp
+++ b/wrapper/FF/ForceFields.pypp.cpp
@@ -6,6 +6,10 @@
 #include "Helpers/clone_const_reference.hpp"
 #include "ForceFields.pypp.hpp"
 
+#ifdef _WIN32
+struct IUnknown;
+#endif
+
 namespace bp = boost::python;
 
 #include "SireBase/combineproperties.h"

--- a/wrapper/Tools/FreeEnergyAnalysis.py
+++ b/wrapper/Tools/FreeEnergyAnalysis.py
@@ -21,7 +21,6 @@ except ImportError:
     raise ImportError('Numpy is not installed. Please install numpy in order to use MBAR for your free energy analysis.')
 from pymbar import MBAR
 from pymbar import timeseries
-import matplotlib.pylab as plt
 import warnings
 
 

--- a/wrapper/python/main.cpp
+++ b/wrapper/python/main.cpp
@@ -180,6 +180,10 @@ int main(int argc, char **argv)
         qputenv("PYTHONHOME", python_home.canonicalPath().toUtf8());
         */
 
+#ifdef _WIN32
+        qputenv("PYTHONHOME", QDir(getInstallDir()).canonicalPath().toUtf8() );
+#endif
+
         //now look at the name of the executable. If there is a script with this
         //name in share/scripts then run that script
         QDir scripts_dir( QString("%1/scripts").arg(getShareDir()) );


### PR DESCRIPTION
Fixed some compiler errors when building on Windows with Visual Studio 2017
Fixed sire_python setting Python home to the wrong location when run on Windows.
Fixed compiler errors with the Python bindings in _CAS_free_functions.pypp.cpp with gcc 5.3.1 and Xcode 8.3.3
Fixed FreeEnergyAnalysis.py failing when matplotlib is not installed