### PR TITLE
Fixed the sending of analytics data (broken since November 2020)

### DIFF
--- a/wrapper/__init__.py
+++ b/wrapper/__init__.py
@@ -321,8 +321,12 @@ def _uploadUsageData():
 
         sent_usage_data = data
 
-        conn = _htc.HTTPConnection("siremol.org")
+        conn = _htc.HTTPSConnection("siremol.org")
         conn.request("POST", "/phonehome/postusagestats.php", params, headers)
+
+        # Next time this break, remember to uncomment the below lines so that
+        # we can inspect the response code and error from the server...
+
         #r1 = conn.getresponse()
         #print(r1.status, r1.reason)
         #print(r1.read())


### PR DESCRIPTION
Fixed the issue that analytics from Sire stopped after November 2020. 

This was because the analytics were being sent via HTTP and the website was sending back a permanent redirect from that date, meaning that the data wasn't collected.

The fix is to switch to HTTPS. This is also safer as it stops sending potentially
sensitive tracking data in plain text.