### PR TITLE
Update FreeEnergyAnalysis.py

### DIFF
--- a/wrapper/Tools/FreeEnergyAnalysis.py
+++ b/wrapper/Tools/FreeEnergyAnalysis.py
@@ -79,11 +79,16 @@ class FreeEnergies(object):
 
     def run_mbar(self, test_overlap = True):
         r"""Runs MBAR free energy estimate """
-        MBAR_obj = MBAR(self._u_kln, self._N_k, verbose=True)
-        self._f_k = MBAR_obj.f_k
+        
         try:
-            (deltaF_ij, dDeltaF_ij, theta_ij) = MBAR_obj.getFreeEnergyDifferences()
+            MBAR_obj = MBAR(self._u_kln, self._N_k, verbose=True)
+            self._f_k = MBAR_obj.f_k
+            (deltaF_ij, dDeltaF_ij, theta_ij) = MBAR_obj.getFreeEnergyDifferences(return_theta=True)
         except:
+            solver_options = {"maximum_iterations":10000,"verbose":True}
+            solver_protocol = {"method":"BFGS","options":solver_options}
+            MBAR_obj = MBAR(self._u_kln, self._N_k, solver_protocol=(solver_protocol,))
+            self._f_k = MBAR_obj.f_k
             (deltaF_ij, dDeltaF_ij, theta_ij) = MBAR_obj.getFreeEnergyDifferences(return_theta=True)
         self._deltaF_mbar = deltaF_ij[0, self._lambda_array.shape[0]-1]
         self._dDeltaF_mbar = dDeltaF_ij[0, self._lambda_array.shape[0]-1]


### PR DESCRIPTION
Add fallback to BFGS solver to increase stability.  See https://github.com/choderalab/pymbar/issues/419 for detail.

Context: 
       I've been running into this `Should have \sum_n W_nk = 1` error frequently when using `analyse_freenrg`. Recently I found a solution in the issue cited above, I've tested it in my data which the default solver is not able to converge, the BFGS worked very well. 