### PR TITLE
Added support for LangevinMiddleIntegrator

### DIFF
--- a/corelib/src/libs/SireMove/openmmfrenergyst.cpp
+++ b/corelib/src/libs/SireMove/openmmfrenergyst.cpp
@@ -2932,6 +2932,8 @@ void OpenMMFrEnergyST::createContext(IntegratorWorkspace &workspace, SireUnits::
             integrator_openmm = new OpenMM::VariableVerletIntegrator(integration_tol); //integration tolerance error unitless
         else if (Integrator_type == "langevin")
             integrator_openmm = new OpenMM::LangevinIntegrator(converted_Temperature, converted_friction, dt);
+        else if (Integrator_type == "langevinmiddle")
+            integrator_openmm = new OpenMM::LangevinMiddleIntegrator(converted_Temperature, converted_friction, dt);
         else if (Integrator_type == "variablelangevin")
             integrator_openmm = new OpenMM::VariableLangevinIntegrator(converted_Temperature, converted_friction, integration_tol);
         else if (Integrator_type == "brownian")


### PR DESCRIPTION
Hello,

This PR is related to us adding support for the `LangevinMiddleIntegrator` in `OpenMM`. While this should be a very simple PR, I couldn't do much testing because I seem to be running into issues when compiling on macOS. I also don't think Azure is performing CI as expected, so any input on this would be welcome. Maybe someone else could test this?

Cheers.