### PR TITLE
Feature apple m1

### DIFF
--- a/build/build_sire.py
+++ b/build/build_sire.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
         print("Compiling on Linux")
     elif platform.system() == "Darwin":
         is_osx = True
-        print("Compiling on OS X")
+        print("Compiling on MacOS")
     elif platform.system() == "Windows":
         exe_suffix = ".exe"
         #print("Sorry - compiling into miniconda on Windows is not supported yet")
@@ -198,12 +198,14 @@ if __name__ == "__main__":
             import PyQt5
             print("Qt5 is already installed...")
         except ImportError:
-            conda_pkgs.append("pyqt=5.12.3")
-            # This is the version for Apple M1
-            #conda_pkgs.append("pyqt=5.15.2")
+            if is_osx and platform.machine() == "arm64":
+                # This is the version needed for Apple M1
+                conda_pkgs.append("pyqt=5.15.2")
+            else:
+                conda_pkgs.append("pyqt=5.12.3")
 
-        # pymbar (not available on aarch64)
-        if platform.machine() != "aarch64":
+        # pymbar (not available on aarch64 and breaks some MacOS)
+        if (not is_osx) and platform.machine() not in ["aarch64", "arm64"]:
             try:
                 import pymbar
                 print("pymbar is already installed...")

--- a/build/build_sire.py
+++ b/build/build_sire.py
@@ -296,7 +296,8 @@ if __name__ == "__main__":
             sys.exit(-1)
 
         if is_osx and platform.machine() == "arm64":
-            # Now update conda
+            # Now update conda - this is needed to fix libffi compatibility
+            # errors that break conda
             cmd = [conda_exe, "update", "-y", "-n", "base",
                    "-c", "defaults", "conda"]
             print("Updating conda base using: '%s'" % " ".join(cmd))
@@ -306,20 +307,13 @@ if __name__ == "__main__":
                 print("Something went wrong with the update!")
                 sys.exit(-1)
 
-            # Need to manually install libffi first, or else it is not
-            # upgraded with the other packages, and conda is then
-            # completely broken!
-            #cmd = [*py_module_install, "libffi"]
-            #print("Installing libffi on MacOS M1 using: '%s'" %
-            #              " ".join(cmd))
-            #status = subprocess.run(cmd)
-
-            #if status.returncode != 0:
-            #    print("Something went wrong installing libffi!")
-            #    sys.exit(-1)
-
-            cmd = "%s config --set channel_priority false" % conda_exe
+            # Need to run this command to prevent conda errors on
+            # some platforms - see
+            # https://github.com/ContinuumIO/anaconda-issues/issues/11246
+            # If we don't do this, then we can't resolve dependencies
+            # on MacOS M1
             print("Setting channel priority to false using: '%s'" % cmd)
+            cmd = "%s config --set channel_priority false" % conda_exe
             status = subprocess.run(cmd.split())
             if status.returncode != 0:
                 print("Failed to set channel priority!")

--- a/build/build_sire.py
+++ b/build/build_sire.py
@@ -371,6 +371,12 @@ if __name__ == "__main__":
             if (not found):
                 cmake_defs.append([a])
 
+        if is_osx:
+            # don't compile with AVX as the resulting binaries won't
+            # work on M1 macs
+            cmake_defs.append("SIRE_DISABLE_AVX=ON")
+            cmake_defs.append("SIRE_DISABLE_AVX512F=ON")
+
     def make_cmd(ncores, install = False):
         if is_windows:
             action = "INSTALL" if install else "ALL_BUILD"

--- a/compile_sire.sh
+++ b/compile_sire.sh
@@ -151,8 +151,12 @@ if [ "$(uname)" == "Darwin" ]; then
     PLATFORM="MacOS"
 
     if [ ${BIT_TYPE} == "arm64" ]; then
-      echo "Compiling an x86_64 executable as Sire does not yet support arm64"
-      BIT_TYPE="x86_64"
+      echo "Compiling a native M1 version of Sire"
+      echo "Using an older conda as the newer one isn't available"
+      MINICONDA_VERSION="4.10.1"
+    else
+      echo "Compiling an X64-64 version of Sire."
+      echo "This version should work on M1 Macs as well as older Intel Macs"
     fi
 
     MINICONDA="${REPO}/Miniconda3-${PYTHON_VERSION}_${MINICONDA_VERSION}-MacOSX-${BIT_TYPE}.sh"

--- a/corelib/src/bundled/install_cpuid.cmake
+++ b/corelib/src/bundled/install_cpuid.cmake
@@ -73,16 +73,9 @@ else()
                 list( APPEND CPUID_OPTIONS "libcpuid_vc10.sln" )
                 message( STATUS "${CMAKE_MAKE_PROGRAM} | ${CPUID_OPTIONS}" )
             else()
-                list( APPEND CPUID_OPTIONS "--enable-static=no" )
-                list( APPEND CPUID_OPTIONS "--enable-shared=yes" )
-                list( APPEND CPUID_OPTIONS "--prefix=${BUNDLE_STAGEDIR}" )
-                list( APPEND CPUID_OPTIONS "--libdir=${BUNDLE_STAGEDIR}/lib" )
-                list( APPEND CPUID_OPTIONS "CC=${CMAKE_C_COMPILER}" )
-
-                if (HAVE_STDINT_H)
-                    list( APPEND CPUID_OPTIONS "CFLAGS=-DHAVE_STDINT_H" )
-                endif()
-                message( STATUS "${CPUID_BUILD_DIR}/configure | ${CPUID_OPTIONS}" )
+                list( APPEND CPUID_OPTIONS "-DCMAKE_INSTALL_PREFIX=${BUNDLE_STAGEDIR}")
+                list( APPEND CPUID_OPTIONS ".")
+                message( STATUS "CPUID | ${CPUID_BUILD_DIR} | ${CPUID_OPTIONS}" )
             endif()
 
             if (MSYS)
@@ -95,15 +88,9 @@ else()
                             )
             else()
                 message( STATUS "Patience... Configuring libcpuid..." )
-                execute_process( COMMAND "libtoolize"
-                                WORKING_DIRECTORY ${CPUID_BUILD_DIR}
-                            )
-                execute_process( COMMAND "autoreconf" "--install"
-                                WORKING_DIRECTORY ${CPUID_BUILD_DIR}
-                            )
-                execute_process( COMMAND "${CPUID_BUILD_DIR}/configure" ${CPUID_OPTIONS}
-                                WORKING_DIRECTORY ${CPUID_BUILD_DIR}
-                            )
+                execute_process( COMMAND "${CMAKE_COMMAND}" ${CPUID_OPTIONS}
+                                 WORKING_DIRECTORY ${CPUID_BUILD_DIR}
+                               )
                 message( STATUS "Patience... Compiling libcpuid..." )
                 execute_process( COMMAND "${CMAKE_MAKE_PROGRAM}" -k -j ${NCORES}
                                 WORKING_DIRECTORY ${CPUID_BUILD_DIR}

--- a/corelib/src/libs/SireBase/cpuid.cpp
+++ b/corelib/src/libs/SireBase/cpuid.cpp
@@ -103,7 +103,6 @@ QDataStream &operator>>(QDataStream &ds, CPUID &cpuid)
     {
         if (not cpuid_present())
         {
-            qDebug() << "Sorry, your CPU doesn't support CPUID";
             return QHash<QString,QString>();
         }
 
@@ -111,7 +110,6 @@ QDataStream &operator>>(QDataStream &ds, CPUID &cpuid)
 
         if (cpuid_get_raw_data(&raw_data) != 0)
         {
-            qDebug() << "Sorry, could not get raw CPUID data";
             return QHash<QString,QString>();
         }
 
@@ -119,7 +117,6 @@ QDataStream &operator>>(QDataStream &ds, CPUID &cpuid)
 
         if (cpu_identify(&raw_data, &cpuid) != 0)
         {
-            qDebug() << "Sorry, could not identify the CPU";
             return QHash<QString,QString>();
         }
 

--- a/corelib/src/libs/SireMM/softcljcomponent.h
+++ b/corelib/src/libs/SireMM/softcljcomponent.h
@@ -58,7 +58,7 @@ const int MAX_ALPHA_VALUES = 6;
     components are available). This combined component gives
     access to each of the individual components, and also
     to the sum of them all
-    
+
     @author Christopher Woods
 */
 class SIREMM_EXPORT SoftCLJComponent : public CLJComponent
@@ -71,20 +71,20 @@ public:
     SoftCLJComponent();
     SoftCLJComponent(const FFName &name);
     SoftCLJComponent(const SireCAS::Symbol &symbol);
-    
+
     SoftCLJComponent(const SoftCLJComponent &other);
-    
+
     ~SoftCLJComponent();
-    
+
     SoftCLJComponent& operator=(const SoftCLJComponent &other);
-    
+
     static const char* typeName();
-    
+
     const char* what() const
     {
         return SoftCLJComponent::typeName();
     }
-    
+
     SoftCLJComponent* clone() const
     {
         return new SoftCLJComponent(*this);
@@ -108,41 +108,41 @@ public:
 
     void setEnergy(FF &ff, const SoftCLJEnergy &value) const;
     void changeEnergy(FF &ff, const SoftCLJEnergy &delta) const;
-    
+
     SireCAS::Symbols symbols() const;
 
 protected:
     void rebuildComponents();
 
-    //the coulomb and LJ components on CLJComponent represent the 
+    //the coulomb and LJ components on CLJComponent represent the
     //total energy of all of the soft core components
-    
+
     /** The individual components for each alpha value in the same
         order as the corresponding alpha values */
     QVector<CLJComponent> alpha_components;
 };
 
-/** This class holds all of the energy component values of 
+/** This class holds all of the energy component values of
     a multi-alpha SoftCLJPotential-derived forcefield
-    
+
     @author Christopher Woods
 */
 class SIREMM_EXPORT SoftCLJEnergy
 {
 public:
     typedef SoftCLJComponent Components;
-    
+
     SoftCLJEnergy();
 
     SoftCLJEnergy(const SoftCLJEnergy &other);
 
     ~SoftCLJEnergy();
-    
+
     static const char* typeName()
     {
         return "SireMM::SoftCLJEnergy";
     }
-    
+
     const char* what() const
     {
         return SoftCLJEnergy::typeName();
@@ -152,42 +152,42 @@ public:
 
     SoftCLJEnergy& operator+=(const SoftCLJEnergy &other);
     SoftCLJEnergy& operator-=(const SoftCLJEnergy &other);
-    
+
     SoftCLJEnergy operator+(const SoftCLJEnergy &other) const;
     SoftCLJEnergy operator-(const SoftCLJEnergy &other) const;
-    
+
     Components components() const
     {
         return Components();
     }
-    
+
     int count() const
     {
         return detail::MAX_ALPHA_VALUES;
     }
-    
+
     int size() const
     {
         return this->count();
     }
-    
+
     void setEnergy(int i, double cnrg, double ljnrg);
-    
+
     double coulomb() const;
     double lj() const;
-    
+
     double coulomb(int i) const;
     double lj(int i) const;
-    
+
     double total() const;
     double total(int i) const;
-    
+
     double component(const CoulombComponent&) const;
     double component(const LJComponent&) const;
-    
+
     double component(const CoulombComponent&, int i) const;
     double component(const LJComponent&, int i) const;
-    
+
     operator double() const
     {
         return total();
@@ -197,7 +197,7 @@ public:
     {
         return SireUnits::Dimension::Energy(total());
     }
-    
+
     operator CoulombEnergy() const
     {
         return CoulombEnergy(coulomb());
@@ -209,11 +209,7 @@ public:
     }
 
 private:
-    #ifdef SIRE_USE_SSE
-    __m128d nrgs[detail::MAX_ALPHA_VALUES];
-    #else
     double nrgs[detail::MAX_ALPHA_VALUES][2];
-    #endif
 };
 
 }

--- a/requirements/requirements_Darwin_arm64.txt
+++ b/requirements/requirements_Darwin_arm64.txt
@@ -11,7 +11,5 @@ clang_osx-64
 clangxx_osx-64
 make
 libtool
-autoconf
-automake
 cmake
 openmm=7.7.0

--- a/requirements/requirements_Darwin_arm64.txt
+++ b/requirements/requirements_Darwin_arm64.txt
@@ -6,7 +6,7 @@ boost=1.74.0
 gsl=2.7
 tbb=2021.5.0
 tbb-devel=2021.5.0
-pyqt=5.12.3
+pyqt=5.15.2
 clang_osx-64
 clangxx_osx-64
 make

--- a/requirements/requirements_Darwin_x86_64.txt
+++ b/requirements/requirements_Darwin_x86_64.txt
@@ -7,6 +7,7 @@ gsl=2.7
 tbb=2021.5.0
 tbb-devel=2021.5.0
 pyqt=5.12.3
+pymbar=3.0.5
 clang_osx-64
 clangxx_osx-64
 make

--- a/wrapper/Maths/_Maths_free_functions.pypp.cpp
+++ b/wrapper/Maths/_Maths_free_functions.pypp.cpp
@@ -464,19 +464,6 @@ void register_free_functions(){
     
     }
 
-    { //::gamma
-    
-        typedef double ( *gamma_function_type )( double );
-        gamma_function_type gamma_function_value( &::gamma );
-        
-        bp::def( 
-            "gamma"
-            , gamma_function_value
-            , ( bp::arg("arg0") )
-            , "Obsolete alias for `lgamma." );
-    
-    }
-
     { //::SireMaths::getAlignment
     
         typedef ::SireMaths::Transform ( *getAlignment_function_type )( ::QVector< SireMaths::Vector > const &,::QVector< SireMaths::Vector > const &,bool );

--- a/wrapper/bundled/install_python.cmake
+++ b/wrapper/bundled/install_python.cmake
@@ -206,22 +206,6 @@ if ( ANACONDA_BUILD )
     endif()
   endif()
 
-  if (APPLE)
-    # we have to make sure that the anaconda python library is called @rpath/libpython...
-    # and that the anaconda python process has the correct executable path
-    execute_process( COMMAND chmod u+w ${PYTHON_LIBRARY} )
-    execute_process( COMMAND ${CMAKE_INSTALL_NAME_TOOL} -id "@rpath/libpython${PYTHON_VERSION}${PYTHON_ABIFLAGS}.dylib" ${PYTHON_LIBRARY} )
-    execute_process( COMMAND ${CMAKE_INSTALL_NAME_TOOL} -add_rpath "@executable_path/../lib" ${PYTHON_EXECUTABLE} )
-
-    # There may also be a python interpreter hidden in python.app/Contents/MacOS/python
-    set( PYTHON_OTHER "${ANACONDA_BASE}/python.app/Contents/MacOS/python" )
-
-    if (EXISTS "${PYTHON_OTHER}")
-      execute_process( COMMAND ${CMAKE_INSTALL_NAME_TOOL} -add_rpath "@executable_path/../lib" ${PYTHON_OTHER} )
-    endif()
-
-  endif()
-
   message( STATUS "Using anaconda/miniconda python in ${PYTHON_LIBRARIES} | ${PYTHON_INCLUDE_DIR}" )
   message( STATUS "Python modules will be installed to ${PYTHON_SITE_DIR}" )
 


### PR DESCRIPTION
Code now compiles and runs natively on Apple M1 processors. This also includes a fix for the X86-64 SSE bug on MacOS, so now we can build and run for either.

BioSimSpace fully installs, with all dependencies bar MDAnalysis available for native M1. All tests pass for both.

For M1, had to run a `conda update` after install, as otherwise subsequent conda installs would update libffi, which then broke conda. Details in `build_sire.py`.