### PR TITLE
Correct Writing of Steps to simfile.dat

### DIFF
--- a/wrapper/Tools/OpenMMMD.py
+++ b/wrapper/Tools/OpenMMMD.py
@@ -1743,8 +1743,8 @@ def runFreeNrg():
         integrator = mdmoves.integrator()
 
         #saving all data
-        beg = (nmoves.val*(i-1)) + energy_frequency.val() # Add energy_frequency beacuse energies not saved at t = 0
-        end = nmoves.val*(i-1)+nmoves.val + energy_frequency.val()
+        beg = (nmoves.val*(i-1)) + energy_frequency.val # Add energy_frequency beacuse energies not saved at t = 0
+        end = nmoves.val*(i-1)+nmoves.val + energy_frequency.val
         steps = list(range(beg, end, energy_frequency.val))
         outdata = getAllData(integrator, steps)
         gradients = integrator.getGradients()

--- a/wrapper/Tools/OpenMMMD.py
+++ b/wrapper/Tools/OpenMMMD.py
@@ -1743,8 +1743,8 @@ def runFreeNrg():
         integrator = mdmoves.integrator()
 
         #saving all data
-        beg = (nmoves.val*(i-1))
-        end = nmoves.val*(i-1)+nmoves.val
+        beg = (nmoves.val*(i-1)) + energy_frequency.val() # Add energy_frequency beacuse energies not saved at t = 0
+        end = nmoves.val*(i-1)+nmoves.val + energy_frequency.val()
         steps = list(range(beg, end, energy_frequency.val))
         outdata = getAllData(integrator, steps)
         gradients = integrator.getGradients()


### PR DESCRIPTION
Hello,

Currently, the step number written to simfile.dat seems to be too low by energy_frequency. This results in a final step number energy_frequency lower than expected, and an initial step number of zero, despite [no data being stored until after the first energy_frequency steps](https://github.com/michellab/Sire/blob/2d430cdb9e8caf1a57ae3960b83ddd779ec2754b/corelib/src/libs/SireMove/openmmfrenergyst.cpp#L3475). I've offset the steps written by simfile.dat by energy_frequency to account for this.

Thanks,
Finlay