### PR TITLE
Update supported Python variants. (Drop py37 add py310.)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,7 +20,7 @@ jobs:
       max-parallel: 9
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10"]
         platform:
           - {
               name: "windows",


### PR DESCRIPTION
As py37 nears EOL, it's starting to cause issues as several dependencies (for Sire and BioSimSpace) are no longer being built against it. This PR drops support for py37 and adds support for py310, which is now supported by conda.