### PR TITLE
Fix Issues with Multiple Distance Restraints Code

### DIFF
--- a/corelib/src/libs/SireMove/openmmfrenergyst.cpp
+++ b/corelib/src/libs/SireMove/openmmfrenergyst.cpp
@@ -1216,7 +1216,7 @@ void OpenMMFrEnergyST::initialise()
        out of the box. */
 
     OpenMM::CustomBondForce * custom_link_bond = new OpenMM::CustomBondForce("delta(min(0, r_eff))*kl*r_eff^2;"
-                                                                             "r_eff=abs(r-reql)-dl;")
+                                                                             "r_eff=abs(r-reql)-dl");
     custom_link_bond->addPerBondParameter("reql");
     custom_link_bond->addPerBondParameter("kl");
     custom_link_bond->addPerBondParameter("dl");

--- a/corelib/src/libs/SireMove/openmmfrenergyst.cpp
+++ b/corelib/src/libs/SireMove/openmmfrenergyst.cpp
@@ -1215,8 +1215,8 @@ void OpenMMFrEnergyST::initialise()
     /* !! CustomBondForce does not (OpenMM 6.2) apply PBC checks so code will be buggy is restraints involve one atom that diffuses
        out of the box. */
 
-    OpenMM::CustomBondForce * custom_link_bond = new OpenMM::CustomBondForce("kl*max(0,d-dl*dl);"
-                                                                             "d=(r-reql)*(r-reql)");
+    OpenMM::CustomBondForce * custom_link_bond = new OpenMM::CustomBondForce("delta(min(0, r_eff))*kl*r_eff^2;"
+                                                                             "r_eff=abs(r-reql)-dl;")
     custom_link_bond->addPerBondParameter("reql");
     custom_link_bond->addPerBondParameter("kl");
     custom_link_bond->addPerBondParameter("dl");


### PR DESCRIPTION
### Issues

I think there are a couple of minor errors in the multiple distance restraints implementation:

1. I think flat-bottomed restraint energy term -  https://github.com/michellab/Sire/blob/489643e51d4d4a641591cb35e10ee12f75e88d36/corelib/src/libs/SireMove/openmmfrenergyst.cpp#L1211 - is incorrect : this is k((R - Requil) ** 2 - R_flat_bottom ** 2), rather than k( | R - Requil | - R_flat_bottom ) ** 2. As a result, the gradient of the half-harmonic potentials is wrong (they are not half-harmonic potentials unless R_flat_bottom = 0, in which case the term is correct). When R_flat_bottom is not 0, the gradients of the "half harmonic" potentials are too great. The correction term seems to be correct in the standardstatecorrection code.

2. In [StandardState.py](http://standardstate.py/), the sin(theta) does not seem to be accounted for in the correction. My understanding is that the correction should be given by:

![image](https://user-images.githubusercontent.com/90148170/202562034-6debac52-f006-42e1-ad7c-5a64206a61cd.png)

but it seems like the orientational volume is calculated linearly based on the number of orientations: https://github.com/michellab/Sire/blob/489643e51d4d4a641591cb35e10ee12f75e88d36/wrapper/Tools/StandardState.py#L360 meaning the sin(theta) term is missed.

### Testing Fix of Issue 1

This PR aims to fix these issues. To test the new code, I have re-run an absolute binding free energy simulation with four distance restraints with 1 A flat-bottomed radii. There was no evidence for a statistical difference between the results, although the errors (95 % C.I.s from 5 independent replicates) were very large:

Bugfixed Results:

vanish: -1.81 +/- 1.06 kcal/mol
discharge: 12.99 +/- 0.64 kcal/mol
restrain: 0.28 +/- 0.12 kcal/mol

Previous Results:

vanish: -1.43 +/- 0.79 kcal/mol
discharge: 13.23 +/- 0.27 kcal/mol
restrain: 0.58 +/- 0.35 kcal/mol

### Testing Fix of Issue 2

I have checked the convergence of the new and old corrections with respect to the correction parameters. For medium-strength restraints:

s | b (Angstrom) | d (Angstrom) | o | corr original (kcal mol-1) +/- 95 % C.I. | corr bugfixed (kcal mol-1) +/- 95 % C.I.
-- | -- | -- | -- | -- | --
1 | 4 | 0.25 | 6 | -9.12 +/- 0.62 | -13.28 +/- 4.16
1 | 4 | 0.25 | 12 | -9.16 +/- 0.14 | -10.19 +/- 0.28
1 | 4 | 0.10 | 12 | -9.16 +/- 0.15 | -10.19 +/- 0.28
1 | 4 | 0.25 | 18 | -9.30 +/- 0.08 | -10.08 +/- 0.05
1 | 4 | 0.25 | 24 | -9.33 +/- 0.08 | -10.03 +/- 0.07
1 | 4 | 0.25 | 30 | -9.35 +/- 0.07 | -10.02 +/- 0.04

For many strong restraints:

s | b (Angstrom) | d (Angstrom) | o | corr original (kcal mol-1) +/- 95 % C.I. | corr bugfixed (kcal mol-1) +/- 95 % C.I.
-- | -- | -- | -- | -- | --
1 | 4 | 0.25 | 6 | -15.64 +/- 6.20 | -61.55 +/- 12.12
1 | 4 | 0.25 | 18 | -14.91 +/- 2.72 | -13.68 +/- 9.60
1 | 4 | 0.25 | 24 | -14.64 +/- 1.99 | -16.32 +/- 0.92
1 | 4 | 0.25 | 30 | -14.27 +/- 1.12 | -15.68 +/- 0.37

For few weak restraints:

s | b (Angstrom) | d (Angstrom) | o | corr original (kcal mol-1) +/- 95 % C.I. | corr bugfixed (kcal mol-1) +/- 95 % C.I.
-- | -- | -- | -- | -- | --
1 | 4 | 0.25 | 6 | -4.85 +/- 0.23 | -11.41 +/- 8.89
1 | 4 | 0.25 | 12 | - | -5.83 +/- 0.24
1 | 4 | 0.10 | 12 | - | -5.83 +/- 0.24
1 | 4 | 0.25 | 18 | - | -5.74 +/- 0.14
1 | 4 | 0.25 | 24 | -5.13 + / - 0.12 | -5.73 +/- 0.15
1 | 4 | 0.25 | 30 | -5.16 +/- 0.12 | -5.72 +/- 0.15

So generally, for the smaller corrections, the original script produces results which start too small and get larger (more negative) and the opposite is true when the sin(theta) term is included. The results for the smaller corrections appear to have converged, giving approximately a 0.6 kcal / mol difference. The correction is larger when the sin(theta) term is included, because without this term excessive weight is given to orientations where theta is 0 or close, and the ligand has not been rotated away from its average position, at which the restraint energy will be minimised.