### PR TITLE
Fix Boresch Analytical Correction

### DIFF
--- a/wrapper/Tools/BoreschAnalyticalCorrection.py
+++ b/wrapper/Tools/BoreschAnalyticalCorrection.py
@@ -42,8 +42,10 @@ def run():
     thetaA0 = boresch_dict["equilibrium_values"]["thetaA0"] # rad
     thetaB0 = boresch_dict["equilibrium_values"]["thetaB0"] # rad
 
-    #force_constants = list(boresch_dict["force_constants"].values()) # kcal mol-1 A-2 or rad-2
-    #prod_force_constants = np.prod(force_constants)
+    # Force constants defined as E = k*x**2, so need to multiply all force constants
+    # by 2 to correct for original definition (E= 0.5*k*x**2)
+    for k in boresch_dict["force_constants"]:
+        boresch_dict["force_constants"][k] *= 2
 
     prefactor = 8*(pi**2)*v0 # Divide this to account for force constants of 0
     force_constants = []
@@ -65,9 +67,6 @@ def run():
             force_constants.append(val)
 
     n_nonzero_k = len(force_constants)
-    # Force constants defined as E = kx**2, so need to multiply by two for use
-    # by 2 to correct for original definition (E= 0.5*k*x**2)
-    prod_force_constants = np.prod(force_constants) * 2
 
     # Calculation
     numerator = prefactor*np.sqrt(prod_force_constants)


### PR DESCRIPTION
This fixes an error I made when changing the Boresch analytical correction script to be consistent with the new definitions of the force constants (E = kx^2 as opposed to 0.5kx^2).