### PR TITLE
bugfix to make the position restraints code compatible with newer pyt…

### DIFF
--- a/wrapper/Tools/OpenMMMD.py
+++ b/wrapper/Tools/OpenMMMD.py
@@ -703,6 +703,8 @@ def setupForcefields(system, space):
 
         for molnum in molnums:
             mol = molecules.molecule(molnum)[0].molecule()
+            if not mol.hasProperty("restrainedAtoms"):
+                continue
             try:
                 mol_restrained_atoms = propertyToAtomNumVectorList(
                     mol.property("restrainedatoms")
@@ -2284,6 +2286,7 @@ def run():
             system = centerSolute(system, space)
 
         if use_restraints.val:
+            print ("Using positional restraints.")
             system = setupRestraints(system)
 
         if turn_on_restraints_mode.val:

--- a/wrapper/Tools/OpenMMMD.py
+++ b/wrapper/Tools/OpenMMMD.py
@@ -703,18 +703,11 @@ def setupForcefields(system, space):
 
         for molnum in molnums:
             mol = molecules.molecule(molnum)[0].molecule()
-            if not mol.hasProperty("restrainedAtoms"):
+            if not mol.hasProperty("restrainedatoms"):
                 continue
-            try:
-                mol_restrained_atoms = propertyToAtomNumVectorList(
-                    mol.property("restrainedatoms")
-                )
-            except UserWarning as error:
-                error_type = re.search(r"(Sire\w*::\w*)", str(error)).group(0)
-                if error_type == "SireBase::missing_property":
-                    continue
-                else:
-                    raise error
+            mol_restrained_atoms = propertyToAtomNumVectorList(
+                mol.property("restrainedatoms")
+            )
 
             for restrained_line in mol_restrained_atoms:
                 atnum = restrained_line[0]
@@ -2506,6 +2499,7 @@ def runFreeNrg():
             system = centerSolute(system, space)
 
         if use_restraints.val:
+            print("Using positional restraints.")
             system = setupRestraints(system)
 
         if turn_on_restraints_mode.val:


### PR DESCRIPTION
Old code relied on catching a UserWarning exception to work out whether a molecule has the property "restrainedatoms" 
This doesn't work on current version of the code. It is possible that the exception behavior has changed in newer python versions. 
This is addressed by adding a simple test for property("restrainedatoms"). 
Also added a print statement to make it clear that position restraints are being applied. 