### PR TITLE
Bugfix LJ Correction

### DIFF
--- a/wrapper/Tools/LJcutoff.py
+++ b/wrapper/Tools/LJcutoff.py
@@ -18,7 +18,7 @@ from Sire.Mol import AtomIdx, MGIdx, MoleculeGroup, MGName, AtomCoords
 from Sire.System import System, PropertyConstraint, PerturbationConstraint
 from Sire.Tools.OpenMMMD import *
 from Sire.Tools import Parameter, resolveParameters
-from Sire.Units import gram, centimeter, angstrom, g_per_mol, kcal_per_mol, mod_electron
+from Sire.Units import gram, centimeter, angstrom, g_per_mol, kcal_per_mol, mod_electron, k_boltz
 from Sire.Vol import PeriodicBox
 
 # Python dependencies
@@ -33,7 +33,7 @@ try:
 except:
     pass
 
-import numpy as np
+import numpy as _np
 #try:
 #    import mdtraj
 #except ImportError:
@@ -197,10 +197,7 @@ def addAnalyticalLRC(system, cutoff, bulk_density):
     solvent = system[MGName("solvent")]
     solvent_mols = solvent.molecules()
     solvent_molnums = solvent_mols.molNums()
-    #
-    # What if solvent contains more than one type of molecule?
-    #
-    #for molnum in solvent_molnums:
+
     avg_sigma = 0.0 * angstrom
     avg_epsilon = 0.0 * kcal_per_mol
     LJsites = 0
@@ -208,7 +205,7 @@ def addAnalyticalLRC(system, cutoff, bulk_density):
     # Loop over all solvent molecules to find something which
     # is not an ion or a protein
     # TODO: Make this more robust - there could be other non-ligand
-    # molecules with n_atoms > 1 < 30
+    # molecules with n_atoms > 1 < 30 or more than one type of solvent
     n_solvent_mols = len(solvent_molnums)
     for i, molnum in enumerate(solvent_molnums):
         mol = solvent_mols.molecule(molnum)[0].molecule()
@@ -348,10 +345,16 @@ def updateSystemfromTraj(system, frame_xyz, cell_lengths, cell_angles):
     return system
 
 def getFreeEnergy(delta_nrgs):
+    # Subtract mean value from all energies
+    # to avoid overflow during exponentiation
+    delta_nrgs = _np.array([nrg.value() for nrg in delta_nrgs])
+    mean_nrg = delta_nrgs.mean()
+    delta_nrgs -= mean_nrg
     free_nrg = FreeEnergyAverage(temperature.val)
     for nrg in delta_nrgs:
-        free_nrg.accumulate(nrg.value())
-    deltaG = free_nrg.average() * kcal_per_mol
+        free_nrg.accumulate(nrg)
+    # Add back the mean
+    deltaG = (free_nrg.average() + mean_nrg)* kcal_per_mol
     return deltaG
 
 def resample(values):
@@ -387,15 +390,11 @@ def runLambda():
     # !!! NEED TO DISABLE CHANGE IN COULOMBIC CUTOFF !!
     #system = zeroCharges(system)
 
-    #import pdb; pdb.set_trace()
-
     # THIS IS THE ONE WITH SHORT CUTOFF
     system_shortc = System()
     system_shortc.copy(system)
-    #import pdb; pdb.set_trace()
     system_shortc = setupLJFF(system_shortc, space, \
                               cutoff=cutoff_dist.val)
-    #import pdb; pdb.set_trace()
 
     # Determine longest cutoff that can be used. Take lowest space dimension,
     # and decrease by 5%
@@ -413,7 +412,6 @@ def runLambda():
                              cutoff=long_cutoff)
     # NOW ADD ANALYTICAL CORRECTION TERM TO longc
     E_lrc_full = addAnalyticalLRC(system_longc, long_cutoff, bulk_rho.val)
-    #import pdb; pdb.set_trace()
     # Now loop over snapshots in dcd and accumulate energies
     start_frame = 1
     end_frame = 1000000000
@@ -448,7 +446,7 @@ def runLambda():
     deltaG = getFreeEnergy(delta_nrgs)
     #print (deltaG)
     nbootstrap = 100
-    deltaG_bootstrap = np.zeros(nbootstrap)
+    deltaG_bootstrap = _np.zeros(nbootstrap)
     for x in range(0,nbootstrap):
         resampled_nrgs = resample(delta_nrgs)
         dG = getFreeEnergy(resampled_nrgs)

--- a/wrapper/Tools/LJcutoff.py
+++ b/wrapper/Tools/LJcutoff.py
@@ -418,7 +418,7 @@ def runLambda():
         #print (system_shortc.energy())
         #print (system_longc.energy())
         system_shortc = updateSystemfromTraj(system_shortc, frames_xyz, cell_lengths, cell_angles)
-        system_longcc = updateSystemfromTraj(system_longc, frames_xyz, cell_lengths, cell_angles)
+        system_longc = updateSystemfromTraj(system_longc, frames_xyz, cell_lengths, cell_angles)
         #print (system_shortc.energy())
         #print (system_longc.energy())
         delta_nrg = (system_longc.energy()+E_lrc_full - system_shortc.energy())

--- a/wrapper/Tools/LJcutoff.py
+++ b/wrapper/Tools/LJcutoff.py
@@ -8,8 +8,18 @@
 
 import os,sys, random
 import math
+from Sire.Base import VariantProperty 
+from Sire.CAS import Symbol, Max
+from Sire.FF import FFName
+from Sire.IO import Amber
+from Sire.Maths import FreeEnergyAverage
+from Sire.MM import IntraCLJFF, InterCLJFF, IntraSoftCLJFF, IntraGroupSoftCLJFF, InterGroupSoftCLJFF, InterGroupCLJFF, CHARMMSwitchingFunction
+from Sire.Mol import AtomIdx, MGIdx, MoleculeGroup, MGName, AtomCoords
+from Sire.System import System, PropertyConstraint, PerturbationConstraint
 from Sire.Tools.OpenMMMD import *
 from Sire.Tools import Parameter, resolveParameters
+from Sire.Units import gram, centimeter, angstrom, g_per_mol, kcal_per_mol, mod_electron
+from Sire.Vol import PeriodicBox
 
 # Python dependencies
 #

--- a/wrapper/Tools/LJcutoff.py
+++ b/wrapper/Tools/LJcutoff.py
@@ -453,3 +453,5 @@ def runLambda():
         deltaG_bootstrap[x] = dG.value()
     dev = deltaG_bootstrap.std()
     print ("DG_LJ = %8.5f +/- %8.5f kcal/mol (1 sigma) " % (deltaG.value(), dev))
+
+    return deltaG, dev

--- a/wrapper/Tools/__init__.py
+++ b/wrapper/Tools/__init__.py
@@ -174,10 +174,13 @@ def resolveParameters(func):
         try:
             retval = func()
         except:
+            retval = None
             sys.exc_info()[0]
             Parameter.pop()
             raise
 
         Parameter.pop()
+
+        return retval
 
     return inner


### PR DESCRIPTION
This PR fixes the LJ correction and closes [this](https://github.com/michellab/Sire/issues/372) issue. 

I found two issues with the script:

1 . The LJ correction script consistently worked for me with Sire 2021.1.0, but started to fail for the complex legs of ABFE calculations for Sire 2022.1.0. This was due to overflow in [the calculation of the exponential average of free energies](https://github.com/michellab/Sire/blob/ff31fd76d8670f27d5b9026a52bd18f4aa9f51b9/wrapper/Tools/LJcutoff.py#L322). For energies more positive than - 420 kcal per mol at 298 K, exp(-E/kT) was just less than 1.7E308, causing no issues. However, for the complex, the LJ energy was greater, causing overflow of the float64s. The smaller LJ energy with the solvent leg system meant there were no issues. I'm not sure what update made for Sire 2022.1.0 caused the LJ energy of my complex leg system to increase to the extent that this issue surfaced. I've fixed this by subtracting the mean of the energies before exponential averaging and adding back on afterwards.

2. Due to changes in molecule ordering made with Sire 2022.1, sometime the protein was selected as the solvent molecule. I've changed the logic to avoid this, but I don't think it's completely robust yet.

 I've made the script compatible with recent changes to OpenMMMD.py. I've also modified runLambda() to return the correction, and resolveParameters() to allow return values to allow me to write a test for the correction. I'll open a PR for the test shortly.